### PR TITLE
fix bug 1182542 - Scrape deeply nested MDN pages, other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,7 @@ output/*/index.html
 docs/_build/*
 
 # Downloaded and generate files
-data/*.json
-data/*.txt
-data/*.csv
+data/
 
 # SQLite databases
 *.sqlite3

--- a/tools/common.py
+++ b/tools/common.py
@@ -45,11 +45,12 @@ class ToolParser(argparse.ArgumentParser):
             user - Add --user option
             password - Add --password option
             data - Add --data option
+            nocache - Add --no-cache option (default with cache)
         """
         super(ToolParser, self).__init__(*args, **kwargs)
 
         self.include_set = set(include or [])
-        valid = set(['api', 'user', 'password', 'data'])
+        valid = set(['api', 'user', 'password', 'data', 'nocache'])
         if self.include_set - valid:
             raise ValueError(
                 'Unknown include items: {}'.format(self.include_set - valid))
@@ -85,6 +86,12 @@ class ToolParser(argparse.ArgumentParser):
                 '-d', '--data', default=_data_dir,
                 action=ToolParser.StripTrailingSlash,
                 help='Output data folder (default: %s)' % _data_dir)
+
+        if 'nocache' in self.include_set:
+            self.add_argument(
+                '--no-cache', action="store_false", default=True,
+                dest="use_cache",
+                help='Ignore cache and redownload files')
 
     def parse_args(self, *args, **kwargs):
         args = super(ToolParser, self).parse_args(*args, **kwargs)
@@ -130,7 +137,8 @@ class Tool(object):
     def cached_download(self, filename, url, headers=None, retries=1):
         """Download a file, then serve it from the cache."""
         path = self.data_file(filename)
-        if not os.path.exists(path):
+        use_cache = getattr(self, 'use_cache', False)
+        if not use_cache or not os.path.exists(path):
             retry = 0
             while retry < retries:
                 if retry == 0:

--- a/tools/common.py
+++ b/tools/common.py
@@ -6,6 +6,7 @@ import codecs
 import getpass
 import hashlib
 import logging
+import os
 import os.path
 import string
 import sys
@@ -137,6 +138,16 @@ class Tool(object):
     def cached_download(self, filename, url, headers=None, retries=1):
         """Download a file, then serve it from the cache."""
         path = self.data_file(filename)
+
+        # Create the folder if it doesn't exist
+        # http://stackoverflow.com/a/14364249/10612
+        folder = os.path.dirname(path)
+        try:
+            os.makedirs(folder)
+        except OSError:
+            if not os.path.isdir(folder):
+                raise
+
         use_cache = getattr(self, 'use_cache', False)
         if not use_cache or not os.path.exists(path):
             retry = 0

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -8,7 +8,7 @@ from resources import Collection, Maturity, Specification
 class LoadSpecData(Tool):
     """Initialize API with specification data from MDN."""
     logger_name = 'tools.load_spec_data'
-    parser_options = ['api', 'user', 'password']
+    parser_options = ['api', 'user', 'password', 'nocache']
 
     def run(self, *args, **kwargs):
         self.login()
@@ -19,7 +19,8 @@ class LoadSpecData(Tool):
         api_collection.load_all('maturities')
         api_collection.load_all('specifications')
 
-        self.logger.info('Reading spec data from MDN templates')
+        cache = "using cache" if self.use_cache else "no cache"
+        self.logger.info('Reading spec data from MDN templates (%s)', cache)
         specname = self.specname_template()
         self.parse_specname(specname, api_collection, local_collection)
         spec2 = self.spec2_template()

--- a/tools/mirror_mdn_features.py
+++ b/tools/mirror_mdn_features.py
@@ -5,7 +5,10 @@ from __future__ import print_function
 from cgi import escape
 from json import loads
 from string import lowercase
+import os.path
 import time
+
+from requests.exceptions import HTTPError
 
 from common import Tool
 from resources import Collection, Feature
@@ -17,12 +20,18 @@ class MirrorMDNFeatures(Tool):
     parser_options = ['api', 'user', 'password', 'data', 'nocache']
     base_mdn_domain = 'https://developer.mozilla.org'
     base_mdn_uri = base_mdn_domain + '/en-US/docs/'
-    rate = 5
 
     def __init__(self, *args, **kwargs):
         super(MirrorMDNFeatures, self).__init__(*args, **kwargs)
         self.rate_limit_start = time.time()
         self.rate_limit_requests = 0
+
+    def get_parser(self):
+        parser = super(MirrorMDNFeatures, self).get_parser()
+        parser.add_argument(
+            '--skip-deletes', action="store_true",
+            help='Skip deleting API resources')
+        return parser
 
     def run(self, *args, **kwargs):
         self.login()
@@ -42,9 +51,12 @@ class MirrorMDNFeatures(Tool):
         self.logger.info('Reading pages from MDN (%s)', cache_state)
         mdn_uris = self.current_mdn_uris()
 
+        # Find new / updated pages
         new_page, needs_url, existing_page = 0, 0, 0
+        seen_uris = set()
         for path, parent_path, raw_slug, title in mdn_uris:
             uri = self.base_mdn_domain + path
+            seen_uris.add(uri)
             feature = feature_by_uri.get(uri)
             if feature:
                 existing_page += 1
@@ -76,7 +88,13 @@ class MirrorMDNFeatures(Tool):
             'MDN URIs gathered, %d found (%d new, %d needs url, %d existing).',
             len(mdn_uris), new_page, needs_url, existing_page)
 
-        return self.sync_changes(api_collection, local_collection)
+        # Find deleted pages
+        for uri, feature in feature_by_uri.items():
+            if uri and uri not in seen_uris:
+                local_collection.remove(feature)
+
+        return self.sync_changes(
+            api_collection, local_collection, self.skip_deletes)
 
     def to_trans(self, text):
         """Convert text to an API translatable string.
@@ -106,16 +124,51 @@ class MirrorMDNFeatures(Tool):
         base_paths = [
             'Web', 'Navigation_timing', 'Server-sent_events', 'WebAPI',
             'WebSockets']
-        headers = {'Accept': 'application/json'}
 
         data = []
         for base_path in base_paths:
-            cache_file = base_path + "_mdn_children.json"
-            mdn_uri = self.base_mdn_uri + base_path + '$children'
-            children = self.cached_download(
-                cache_file, mdn_uri, headers=headers, retries=60)
-            data.extend(self.gather_mdn_json(loads(children)))
+            data.extend(self.crawl_mdn(base_path))
         return data
+
+    def crawl_mdn(self, path, parent_path=None, attempt=0):
+        """Recursively crawl MDN paths."""
+        cache_file = os.path.join("mdn_children", path + ".json")
+        mdn_uri = self.base_mdn_uri + path
+        children_uri = mdn_uri + '$children?depth=1'
+        headers = {'Accept': 'application/json'}
+        try:
+            children_data = self.cached_download(
+                cache_file, children_uri, headers=headers, retries=60)
+        except HTTPError as e:
+            self.logger.error('Error downloading %s: %s', children_uri, e)
+            return []
+
+        try:
+            mdn_json = loads(children_data)
+        except ValueError as e:
+            self.logger.error(
+                'Unable to decode JSON in %s: %s', cache_file, e)
+            if attempt < 3:
+                os.remove(cache_file)
+                return self.crawl_mdn(path, parent_path, attempt + 1)
+            else:
+                raise
+        if mdn_json:
+            path = mdn_json['url']
+            title = mdn_json['title']
+            slug = mdn_json['slug']
+            data = [(path, parent_path, slug, title)]
+            for subjson in mdn_json['subpages']:
+                subslug = subjson['slug']
+                if subslug.endswith('/'):
+                    # /en-US/docs/Web/Events/onconnected redirected
+                    self.logger.warning('Invalid slug for %s', subjson)
+                else:
+                    data.extend(self.crawl_mdn(subslug, parent_path=path))
+            return data
+        else:
+            self.logger.warning('No data at %s', path)
+            return []
 
     def known_features(self, collection):
         """Load URIs from collection's features."""
@@ -125,39 +178,6 @@ class MirrorMDNFeatures(Tool):
             slug = feature.slug
             uris.append((uri, slug, feature))
         return uris
-
-    def gather_mdn_json(self, mdn_json, parent_path=None):
-        """Recursively gather data from MDN JSON."""
-        path = mdn_json['url']
-        title = mdn_json['title']
-        slug = mdn_json['slug']
-        subpages = mdn_json['subpages']
-        data = [(path, parent_path, slug, title)]
-        for subjson in subpages:
-            data.extend(self.gather_mdn_json(subjson, path))
-        return data
-
-    def rate_limit(self):
-        """Pause and return True if exceeding the rate limit."""
-        self.rate_limit_requests += 1
-
-        # Sleep if we need to wait for the rate limit
-        current_time = time.time()
-        if self.rate:
-            elapsed = current_time - self.rate_limit_start
-            target = (
-                self.rate_limit_start +
-                float(self.rate_limit_requests) / self.rate)
-            current_rate = float(self.rate_limit_requests) / elapsed
-            if current_time < target:
-                rest = int(target - current_time) + 1
-                self.logger.warning(
-                    "%d pages fetched, %0.2f per second, target rate %d per"
-                    " second.  Resting %d seconds.",
-                    self.rate_limit_requests, current_rate, self.rate, rest)
-                time.sleep(rest)
-                return True
-        return False
 
 
 if __name__ == '__main__':

--- a/tools/mirror_mdn_features.py
+++ b/tools/mirror_mdn_features.py
@@ -14,7 +14,7 @@ from resources import Collection, Feature
 class MirrorMDNFeatures(Tool):
     """Create and Update API features for MDN pages."""
     logger_name = 'tools.mirror_mdn_features'
-    parser_options = ['api', 'user', 'password', 'data']
+    parser_options = ['api', 'user', 'password', 'data', 'nocache']
     base_mdn_domain = 'https://developer.mozilla.org'
     base_mdn_uri = base_mdn_domain + '/en-US/docs/'
     rate = 5
@@ -38,7 +38,8 @@ class MirrorMDNFeatures(Tool):
         feature_by_slug = dict((k[1], k[2]) for k in features)
         slugs = set(feature_by_slug.keys())
 
-        self.logger.info('Reading pages from MDN')
+        cache_state = "using cache" if self.use_cache else "no cache"
+        self.logger.info('Reading pages from MDN (%s)', cache_state)
         mdn_uris = self.current_mdn_uris()
 
         new_page, needs_url, existing_page = 0, 0, 0


### PR DESCRIPTION
Florian Sholtz and the MDN team have reduced a lot of the [importer issues](https://browsercompat.herokuapp.com/importer/issues), and have requested a re-scrape of MDN to see if new content has additional issues.  This PR includes tool improvements that will help the process.  This code has **not** been run against https://browsercompat.herokuapp.com, since we're trying to do code reviews before "production" pushes.

* Fix [bug 1182542](https://bugzilla.mozilla.org/show_bug.cgi?id=1182542) - Use recursive calls to ``$children`` to discover MDN URLs more than 5 levels deep.
* Handle various error conditions with ``$children`` API
* Make it easy to get fresh content with ``--no-cache``
* Re-scrape MDN with ``import_mdn.py``.

If you want to run this locally:
* Setup browsercompat project
  * Add a superuser with / username+password
  * Optionally populate with data from https://github.com/mdn/browsercompat-data (will have less "unknown_version" type errors)
  * Optionally run with memcache 
* With a good network connection and power supply, run:
  *  ``time tools/mirror_mdn_features.py`` - after about 60 minutes, will prompt to make changes, then 5 - 10 minutes to commit changes.  For me, got 841 new pages, 19 changed, 969 deleted, 6023 the same.
  * ``time tools/import_mdn.py`` - takes about 6.5 hours to parse 5877 pages.
