### PR TITLE
fix bug 1194565 and bug 1134584 - Importer issues

### DIFF
--- a/mdn/models.py
+++ b/mdn/models.py
@@ -80,7 +80,7 @@ class FeaturePage(models.Model):
 
     def slug(self):
         path = self.path()
-        prefix = '/en-US/docs/'
+        prefix = '/en-US/'
         assert path.startswith(prefix)
         return path[len(prefix):]
 

--- a/mdn/tasks.py
+++ b/mdn/tasks.py
@@ -55,12 +55,6 @@ def fetch_meta(featurepage_id):
     next_task_args = []
     if r.url != url and not r.url.endswith('$json'):
         # There was a redirect to the regular page
-        '''
-        if r.url.endswith('$json'):
-            # There was a redirect to another meta (zone change)
-            fp.url = r.url[:-len('$json')]
-        else:
-        '''
         meta.delete()
         fp.url = r.url
         fp.status = fp.STATUS_META

--- a/mdn/tasks.py
+++ b/mdn/tasks.py
@@ -53,9 +53,14 @@ def fetch_meta(featurepage_id):
     r = requests.get(url, headers={'Cache-Control': 'no-cache'})
     next_task = None
     next_task_args = []
-    if r.url != url:
+    if r.url != url and not r.url.endswith('$json'):
         # There was a redirect to the regular page
-        assert not r.url.endswith('$json'), r.url
+        '''
+        if r.url.endswith('$json'):
+            # There was a redirect to another meta (zone change)
+            fp.url = r.url[:-len('$json')]
+        else:
+        '''
         meta.delete()
         fp.url = r.url
         fp.status = fp.STATUS_META
@@ -68,6 +73,9 @@ def fetch_meta(featurepage_id):
         meta.status = meta.STATUS_ERROR
         next_task = r.raise_for_status
     else:
+        if r.url != url and r.url.endswith('$json'):
+            # There was a redirect to another meta (zone change)
+            fp.url = r.url[:-len('$json')]
         try:
             meta.raw = dumps(r.json())
         except ValueError:

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -58,7 +58,7 @@ class TestFeaturePageModel(TestCase):
         self.assertEqual("https://developer.mozilla.org", self.fp.domain())
 
     def test_str(self):
-        expected = "Fetching Metadata for Web/CSS/float"
+        expected = "Fetching Metadata for docs/Web/CSS/float"
         self.assertEqual(expected, str(self.fp))
 
     def test_meta_new(self):

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -162,8 +162,8 @@ class TestFetchMetaTask(TestCase):
 
     def test_redirect_to_zone(self):
         data = {
-            'locale': 'en-US', 'title': 'display',
-            'url': '/en-US/CSS/display',
+            'locale': 'en-US', 'title': 'float',
+            'url': '/en-US/CSS/float',
             'translations': []}
         self.response.json.side_effect = None
         self.response.json.return_value = data

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -99,11 +99,11 @@ class TestFetchMetaTask(TestCase):
 
     def test_good_call(self):
         data = {
-            'locale': 'en-US', 'title': 'display',
-            'url': '/en-US/docs/Web/CSS/display',
+            'locale': 'en-US', 'title': 'float',
+            'url': '/en-US/docs/Web/CSS/float',
             'translations': [{
-                'locale': 'es', 'title': 'display',
-                'url': '/es/docs/Web/CSS/display'}]}
+                'locale': 'es', 'title': 'float',
+                'url': '/es/docs/Web/CSS/float'}]}
         self.response.json.side_effect = None
         self.response.json.return_value = data
         self.mocked_fetch_all.side_effect = None
@@ -159,6 +159,28 @@ class TestFetchMetaTask(TestCase):
         self.assertEqual(fp.STATUS_META, fp.status)
         self.assertEqual(new_url, fp.url)
         mocked_delay.assertCalledOnce(self.fp.id)
+
+    def test_redirect_to_zone(self):
+        data = {
+            'locale': 'en-US', 'title': 'display',
+            'url': '/en-US/CSS/display',
+            'translations': []}
+        self.response.json.side_effect = None
+        self.response.json.return_value = data
+        self.response.text = '<html>Some page</html>'
+        new_url = 'https://developer.mozilla.org/en-US/CSS/float'
+        self.response.url = new_url + '$json'
+        self.mocked_fetch_all.side_effect = None
+
+        fetch_meta(self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PAGES, fp.status)
+        self.assertEqual(new_url, fp.url)
+        self.assertEqual([], fp.data['meta']['scrape']['issues'])
+        meta = fp.meta()
+        self.assertEqual(meta.STATUS_FETCHED, meta.status)
+        self.assertEqual(data, meta.data())
+        self.mocked_fetch_all.assertCalledOnce(self.fp.id)
 
 
 class TestFetchAllTranslationsTask(TestCase):

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -41,7 +41,7 @@ class TestFeaturePageListView(TestCase):
         FeaturePage.objects.create(
             url="https://developer.mozilla.org/en-US/docs/Other",
             feature_id=2)
-        url = self.url + "?topic=Web"
+        url = self.url + "?topic=docs/Web"
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         pages = response.context_data['page_obj']
@@ -140,7 +140,7 @@ class TestFeaturePageSearch(TestCase):
             url=self.mdn_url, feature_id=self.feature.id)
         url = "https://developer.mozilla.org/en-US/docs/Web"
         response = self.client.get(self.url, {'url': url})
-        next_url = reverse('feature_page_list') + '?topic=Web'
+        next_url = reverse('feature_page_list') + '?topic=docs/Web'
         self.assertRedirects(response, next_url)
 
     def test_post_found_topic_trailing_slash(self):
@@ -148,7 +148,7 @@ class TestFeaturePageSearch(TestCase):
             url=self.mdn_url, feature_id=self.feature.id)
         url = "https://developer.mozilla.org/en-US/docs/Web/"
         response = self.client.get(self.url, {'url': url})
-        next_url = reverse('feature_page_list') + '?topic=Web'
+        next_url = reverse('feature_page_list') + '?topic=docs/Web'
         self.assertRedirects(response, next_url)
 
     def test_not_found_with_perms(self):

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -15,7 +15,7 @@ from django.views.generic.edit import CreateView, FormMixin, UpdateView
 from .models import FeaturePage, Issue, ISSUES, SEVERITIES, validate_mdn_url
 from .tasks import start_crawl, parse_page
 
-DEV_PREFIX = 'https://developer.mozilla.org/en-US/docs/'
+DEV_PREFIX = 'https://developer.mozilla.org/en-US/'
 
 
 def can_create(user):
@@ -48,17 +48,17 @@ class FeaturePageListView(ListView):
         ctx['request'] = self.request
         ctx['topic'] = topic
         ctx['topics'] = sorted((
-            'Web/API',
-            'Web/Accessibility',
-            'Web/CSS',
-            'Web/Events',
-            'Web/Guide',
-            'Web/HTML',
-            'Web/JavaScript',
-            'Web/MathML',
-            'Web/SVG',
-            'Web/XPath',
-            'Web/XSLT',
+            'docs/Web/API',
+            'docs/Web/Accessibility',
+            'docs/Web/CSS',
+            'docs/Web/Events',
+            'docs/Web/Guide',
+            'docs/Web/HTML',
+            'docs/Web/JavaScript',
+            'docs/Web/MathML',
+            'docs/Web/SVG',
+            'docs/Web/XPath',
+            'docs/Web/XSLT',
         ))
         return ctx
 

--- a/tools/client.py
+++ b/tools/client.py
@@ -80,7 +80,7 @@ class Client(object):
         if response.status_code not in expected_statuses:
             raise APIException(
                 '%s %s: Unexpected response' % (method, url),
-                response.status_code, response.content)
+                response.status_code, response.content, data_json)
 
         end = time()
         logger.debug('%s %s completed in %0.1fs', method, url, end - start)

--- a/webplatformcompat/tests/test_validators.py
+++ b/webplatformcompat/tests/test_validators.py
@@ -83,8 +83,8 @@ class SharedVersionAndStatusTests(object):
     def test_float_unknown_ok(self):
         self.assertPasses("1.0", "unknown")
 
-    def test_double_dotted_failed(self):
-        self.assertFailsValidation("1.0.5556", "unknown")
+    def test_double_dotted_ok(self):
+        self.assertPasses("1.0.1", "unknown")
 
     def test_current_current_ok(self):
         self.assertPasses("current", "current")

--- a/webplatformcompat/validators.py
+++ b/webplatformcompat/validators.py
@@ -1,3 +1,5 @@
+import re
+
 from django.core.exceptions import ValidationError
 from django.db.models import Model
 from django.utils.deconstruct import deconstructible
@@ -53,6 +55,8 @@ class LanguageDictValidator(object):
 class VersionAndStatusValidator(object):
     """For Version resource, restrict version/status combinations."""
 
+    re_numeric = re.compile(r"^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)$")
+
     def __init__(self):
         """Initialize for Django model validation."""
         self.instance = None
@@ -90,13 +94,8 @@ class VersionAndStatusValidator(object):
         if not version:
             # DRF will catch in field validation
             raise self.Error({"version": ["This field may not be blank."]})
-        try:
-            float(version)
-        except ValueError:
-            is_numeric = False
-        else:
-            is_numeric = True
 
+        is_numeric = bool(self.re_numeric.match(version))
         numeric_only = ['beta', 'retired beta', 'retired', 'unknown']
         if status in numeric_only and not is_numeric:
             msg = 'With status "{0}", version must be numeric.'.format(status)

--- a/webplatformcompat/validators.py
+++ b/webplatformcompat/validators.py
@@ -55,6 +55,7 @@ class LanguageDictValidator(object):
 class VersionAndStatusValidator(object):
     """For Version resource, restrict version/status combinations."""
 
+    # From http://stackoverflow.com/questions/82064
     re_numeric = re.compile(r"^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)$")
 
     def __init__(self):

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -263,7 +263,7 @@ if environ.get('MDN_ALLOWED_URL_PREFIXES') and not TESTING:
     raw = environ['MDN_ALLOWED_URL_PREFIXES']
     MDN_ALLOWED_URLS = tuple(raw.split(','))
 else:
-    MDN_ALLOWED_URLS = ('https://developer.mozilla.org/en-US/docs/', )
+    MDN_ALLOWED_URLS = ('https://developer.mozilla.org/en-US/', )
 
 #
 # 3rd Party Libraries


### PR DESCRIPTION
This fixes [bug 1194565](https://bugzilla.mozilla.org/show_bug.cgi?id=1194565), a 500 error when the importer tries to import a URL that has been turned into a zone URL.  https://browsercompat.herokuapp.com/importer/6247, the import for https://developer.mozilla.org/en-US/docs/Web/Apps/Design/Patterns/Entry_sheet, shows this error when you reset the page.

Firefox OS 1.0.1 is loaded in the browsercompat-data set, but `tools/upload_data.py` couldn't load it because the API was rejecting it.  This required fixing [bug 1134584](https://bugzilla.mozilla.org/show_bug.cgi?id=1134584) as well. 

To test:

1. Start with a fresh database
2. `./manage.py syncdb`, add a superuser
3. Checkout [browsercompat-data](https://github.com/mdn/browsercompat-data)
4. Run the server: `DJANGO_DEBUG=1 ./manage.py runserver`
5. Load the production data set, `tools/upload_data.py --d <path to browsercompat-data/data>`
6. Login with the superuser account, http://localhost:8000/accounts/login/
7. Load the importer http://localhost:8000/importer/.
8. Search for https://developer.mozilla.org/en-US/docs/Web/Apps/Design/Patterns/Entry_sheet
9. Select the slug 'web-apps-design-patterns-entry_sheet1' for the feature
10. The page is scraped, and the URL changes to https://developer.mozilla.org/en-US/Apps/Design/Patterns/Entry_sheet 