### PR TITLE
bug 1181140 - Handle {{Compat*}} macros

### DIFF
--- a/mdn/compatibility.py
+++ b/mdn/compatibility.py
@@ -10,12 +10,11 @@ from parsimonious.grammar import Grammar
 
 from .html import HnElement, HTMLElement, HTMLSelfClosingElement, HTMLText
 from .kumascript import (
-    CompatAndroid, CompatGeckoDesktop, CompatGeckoFxOS, CompatGeckoMobile,
-    CompatNightly, CompatNo, CompatUnknown, CompatVersionUnknown,
-    DeprecatedInline, ExperimentalInline, KumaScript, KumaVisitor,
-    NonStandardInline, NotStandardInline, PropertyPrefix,
+    CompatGeckoFxOS, CompatKumaScript, CompatNightly, CompatNo, CompatUnknown,
+    CompatVersionUnknown, DeprecatedInline, ExperimentalInline, KumaScript,
+    KumaVisitor, NonStandardInline, NotStandardInline, PropertyPrefix,
     kumascript_grammar_source)
-from .utils import is_new_id, join_content
+from .utils import is_new_id, format_version, join_content
 from .visitor import Extractor
 
 compat_shared_grammar_source = r"""
@@ -527,12 +526,7 @@ class CellVersion(HTMLText):
 
     def __init__(self, version, engine_version=None, **kwargs):
         super(CellVersion, self).__init__(**kwargs)
-        if '.' in version:
-            self.version = version
-        else:
-            assert version
-            assert int(version)
-            self.version = version + '.0'
+        self.version = format_version(version)
         self.engine_version = engine_version or None
 
     def __str__(self):
@@ -643,14 +637,13 @@ class CompatSupportVisitor(CompatBaseVisitor):
             self.support['support'] = 'no'
         elif isinstance(processed, CompatUnknown):
             pass  # Don't record unknown support in API
-        elif isinstance(processed, (
-                CompatGeckoDesktop, CompatGeckoMobile, CompatAndroid)):
-            version_name = str(processed.version)
-            if self.is_valid_version(version_name):
-                self.set_version(version_name, processed)
         elif isinstance(processed, CompatGeckoFxOS):
             if not (processed.bad_version or processed.bad_override):
                 self.set_version(str(processed.version), processed)
+        elif isinstance(processed, CompatKumaScript):
+            version_name = str(processed.version)
+            if self.is_valid_version(version_name):
+                self.set_version(version_name, processed)
         elif isinstance(processed, PropertyPrefix):
             self.support['prefix'] = processed.prefix
         elif isinstance(processed, Footnote):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -381,6 +381,11 @@ class CompatOpera(CompatBasicKumaScript):
     arg_names = ['OperaVer']
 
 
+class CompatSafari(CompatBasicKumaScript):
+    # https://developer.mozilla.org/en-US/docs/Template:CompatSafari
+    arg_names = ['SafariVer']
+
+
 class CompatUnknown(KnownKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:CompatUnknown
     expected_scopes = set(('compatibility support',))
@@ -642,6 +647,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'CompatNightly': CompatNightly,
         'CompatNo': CompatNo,
         'CompatOpera': CompatOpera,
+        'CompatSafari': CompatSafari,
         'CompatUnknown': CompatUnknown,
         'CompatVersionUnknown': CompatVersionUnknown,
         'CompatibilityTable': CompatibilityTable,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -361,6 +361,11 @@ class CompatGeckoMobile(CompatKumaScript):
             return "{}.0".format(nversion)
 
 
+class CompatIE(CompatBasicKumaScript):
+    # https://developer.mozilla.org/en-US/docs/Template:CompatIE
+    arg_names = ['IEver']
+
+
 class CompatNightly(KnownKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:CompatNightly
     expected_scopes = set(('compatibility support',))
@@ -628,6 +633,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'CompatGeckoDesktop': CompatGeckoDesktop,
         'CompatGeckoFxOS': CompatGeckoFxOS,
         'CompatGeckoMobile': CompatGeckoMobile,
+        'CompatIE': CompatIE,
         'CompatNightly': CompatNightly,
         'CompatNo': CompatNo,
         'CompatUnknown': CompatUnknown,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -368,6 +368,8 @@ class CompatIE(CompatBasicKumaScript):
 
 class CompatNightly(KnownKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:CompatNightly
+    max_args = 1
+    arg_names = ['browser']
     expected_scopes = set(('compatibility support',))
 
 

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -34,6 +34,7 @@ from parsimonious.nodes import Node
 
 from .data import Data
 from .html import HTMLInterval, HTMLText, HTMLVisitor, html_grammar_source
+from .utils import format_version
 
 kumascript_grammar_source = html_grammar_source + r"""
 #
@@ -215,13 +216,17 @@ class CompatKumaScript(KnownKumaScript):
         return self.version
 
 
-class CompatAndroid(CompatKumaScript):
-    # https://developer.mozilla.org/en-US/docs/Template:CompatAndroid
-    arg_names = ['AndroidVersion']
+class CompatBasicKumaScript(CompatKumaScript):
+    """Base class for KumaScript specifying the actual browser version"""
 
     def __init__(self, **kwargs):
-        super(CompatAndroid, self).__init__(**kwargs)
-        self.version = self.arg(0)
+        super(CompatBasicKumaScript, self).__init__(**kwargs)
+        self.version = format_version(self.arg(0))
+
+
+class CompatAndroid(CompatBasicKumaScript):
+    # https://developer.mozilla.org/en-US/docs/Template:CompatAndroid
+    arg_names = ['AndroidVersion']
 
 
 class CompatGeckoDesktop(CompatKumaScript):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -229,6 +229,11 @@ class CompatAndroid(CompatBasicKumaScript):
     arg_names = ['AndroidVersion']
 
 
+class CompatChrome(CompatBasicKumaScript):
+    # https://developer.mozilla.org/en-US/docs/Template:CompatChrome
+    arg_names = ['ChromeVer']
+
+
 class CompatGeckoDesktop(CompatKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:CompatGeckoDesktop
     arg_names = ['GeckoVersion']
@@ -619,6 +624,7 @@ class BaseKumaVisitor(HTMLVisitor):
 
     known_kumascript = {
         'CompatAndroid': CompatAndroid,
+        'CompatChrome': CompatChrome,
         'CompatGeckoDesktop': CompatGeckoDesktop,
         'CompatGeckoFxOS': CompatGeckoFxOS,
         'CompatGeckoMobile': CompatGeckoMobile,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -376,6 +376,11 @@ class CompatNo(KnownKumaScript):
     expected_scopes = set(('compatibility support',))
 
 
+class CompatOpera(CompatBasicKumaScript):
+    # https://developer.mozilla.org/en-US/docs/Template:CompatOpera
+    arg_names = ['OperaVer']
+
+
 class CompatUnknown(KnownKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:CompatUnknown
     expected_scopes = set(('compatibility support',))
@@ -636,6 +641,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'CompatIE': CompatIE,
         'CompatNightly': CompatNightly,
         'CompatNo': CompatNo,
+        'CompatOpera': CompatOpera,
         'CompatUnknown': CompatUnknown,
         'CompatVersionUnknown': CompatVersionUnknown,
         'CompatibilityTable': CompatibilityTable,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -381,6 +381,11 @@ class CompatOpera(CompatBasicKumaScript):
     arg_names = ['OperaVer']
 
 
+class CompatOperaMobile(CompatBasicKumaScript):
+    # https://developer.mozilla.org/en-US/docs/Template:CompatOperaMobile
+    arg_names = ['OperaVer']
+
+
 class CompatSafari(CompatBasicKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:CompatSafari
     arg_names = ['SafariVer']
@@ -647,6 +652,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'CompatNightly': CompatNightly,
         'CompatNo': CompatNo,
         'CompatOpera': CompatOpera,
+        'CompatOperaMobile': CompatOperaMobile,
         'CompatSafari': CompatSafari,
         'CompatUnknown': CompatUnknown,
         'CompatVersionUnknown': CompatVersionUnknown,

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -8,11 +8,12 @@ from mdn.html import HTMLText
 from mdn.kumascript import (
     CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
-    CompatOpera, CompatSafari, CompatUnknown, CompatVersionUnknown,
-    CompatibilityTable, DOMxRef, DeprecatedInline, ExperimentalInline,
-    KumaHTMLElement, KnownKumaScript, KumaScript, KumaVisitor,
-    NonStandardInline, NotStandardInline, PropertyPrefix, Spec2, SpecName,
-    UnknownKumaScript, WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
+    CompatOpera, CompatOperaMobile, CompatSafari, CompatUnknown,
+    CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline,
+    ExperimentalInline, KumaHTMLElement, KnownKumaScript, KumaScript,
+    KumaVisitor, NonStandardInline, NotStandardInline, PropertyPrefix, Spec2,
+    SpecName, UnknownKumaScript, WhyNoSpecBlock, XrefCSSLength,
+    kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
 from .test_html import TestVisitor as TestHTMLVisitor
@@ -639,6 +640,10 @@ class TestVisitor(TestHTMLVisitor):
     def test_compatopera(self):
         self.assert_compat_version(
             '{{CompatOpera("9")}}', CompatOpera, '9.0')
+
+    def test_compatoperamobile(self):
+        self.assert_compat_version(
+            '{{CompatOperaMobile("11.5")}}', CompatOperaMobile, '11.5')
 
     def test_compatsafari(self):
         self.assert_compat_version(

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -7,12 +7,12 @@ from django.utils.six import text_type
 from mdn.html import HTMLText
 from mdn.kumascript import (
     CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
-    CompatGeckoFxOS, CompatGeckoMobile, CompatNightly, CompatNo, CompatUnknown,
-    CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline,
-    ExperimentalInline, KumaHTMLElement, KnownKumaScript, KumaScript,
-    KumaVisitor, NonStandardInline, NotStandardInline, PropertyPrefix, Spec2,
-    SpecName, UnknownKumaScript, WhyNoSpecBlock, XrefCSSLength,
-    kumascript_grammar)
+    CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
+    CompatUnknown, CompatVersionUnknown, CompatibilityTable, DOMxRef,
+    DeprecatedInline, ExperimentalInline, KumaHTMLElement, KnownKumaScript,
+    KumaScript, KumaVisitor, NonStandardInline, NotStandardInline,
+    PropertyPrefix, Spec2, SpecName, UnknownKumaScript, WhyNoSpecBlock,
+    XrefCSSLength, kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
 from .test_html import TestVisitor as TestHTMLVisitor
@@ -631,3 +631,7 @@ class TestVisitor(TestHTMLVisitor):
     def test_compatchrome(self):
         self.assert_compat_version(
             '{{CompatChrome("10.0")}}', CompatChrome, '10.0')
+
+    def test_compatie(self):
+        self.assert_compat_version(
+            '{{CompatIE("9")}}', CompatIE, '9.0')

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -8,11 +8,11 @@ from mdn.html import HTMLText
 from mdn.kumascript import (
     CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
-    CompatUnknown, CompatVersionUnknown, CompatibilityTable, DOMxRef,
-    DeprecatedInline, ExperimentalInline, KumaHTMLElement, KnownKumaScript,
-    KumaScript, KumaVisitor, NonStandardInline, NotStandardInline,
-    PropertyPrefix, Spec2, SpecName, UnknownKumaScript, WhyNoSpecBlock,
-    XrefCSSLength, kumascript_grammar)
+    CompatOpera, CompatUnknown, CompatVersionUnknown, CompatibilityTable,
+    DOMxRef, DeprecatedInline, ExperimentalInline, KumaHTMLElement,
+    KnownKumaScript, KumaScript, KumaVisitor, NonStandardInline,
+    NotStandardInline, PropertyPrefix, Spec2, SpecName, UnknownKumaScript,
+    WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
 from .test_html import TestVisitor as TestHTMLVisitor
@@ -635,3 +635,7 @@ class TestVisitor(TestHTMLVisitor):
     def test_compatie(self):
         self.assert_compat_version(
             '{{CompatIE("9")}}', CompatIE, '9.0')
+
+    def test_compatopera(self):
+        self.assert_compat_version(
+            '{{CompatOpera("9")}}', CompatOpera, '9.0')

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -8,11 +8,11 @@ from mdn.html import HTMLText
 from mdn.kumascript import (
     CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
-    CompatOpera, CompatUnknown, CompatVersionUnknown, CompatibilityTable,
-    DOMxRef, DeprecatedInline, ExperimentalInline, KumaHTMLElement,
-    KnownKumaScript, KumaScript, KumaVisitor, NonStandardInline,
-    NotStandardInline, PropertyPrefix, Spec2, SpecName, UnknownKumaScript,
-    WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
+    CompatOpera, CompatSafari, CompatUnknown, CompatVersionUnknown,
+    CompatibilityTable, DOMxRef, DeprecatedInline, ExperimentalInline,
+    KumaHTMLElement, KnownKumaScript, KumaScript, KumaVisitor,
+    NonStandardInline, NotStandardInline, PropertyPrefix, Spec2, SpecName,
+    UnknownKumaScript, WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
 from .test_html import TestVisitor as TestHTMLVisitor
@@ -639,3 +639,7 @@ class TestVisitor(TestHTMLVisitor):
     def test_compatopera(self):
         self.assert_compat_version(
             '{{CompatOpera("9")}}', CompatOpera, '9.0')
+
+    def test_compatsafari(self):
+        self.assert_compat_version(
+            '{{CompatSafari("2")}}', CompatSafari, '2.0')

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -167,6 +167,14 @@ class TestCompatNightly(TestCase):
         self.assertFalse(ks.issues)
         self.assertEqual(text_type(ks), raw)
 
+    def test_with_arg(self):
+        raw = '{{CompatNightly("firefox")}}'
+        ks = CompatNightly(
+            raw=raw, args=['firefox'], scope='compatibility support')
+        self.assertEqual(ks.to_html(), '')
+        self.assertFalse(ks.issues)
+        self.assertEqual(text_type(ks), raw)
+
 
 class TestCompatNo(TestCase):
     # https://developer.mozilla.org/en-US/docs/Template:CompatNo

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -6,8 +6,8 @@ from django.utils.six import text_type
 
 from mdn.html import HTMLText
 from mdn.kumascript import (
-    CSSBox, CSSxRef, CompatAndroid, CompatGeckoDesktop, CompatGeckoFxOS,
-    CompatGeckoMobile, CompatNightly, CompatNo, CompatUnknown,
+    CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
+    CompatGeckoFxOS, CompatGeckoMobile, CompatNightly, CompatNo, CompatUnknown,
     CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline,
     ExperimentalInline, KumaHTMLElement, KnownKumaScript, KumaScript,
     KumaVisitor, NonStandardInline, NotStandardInline, PropertyPrefix, Spec2,
@@ -618,3 +618,16 @@ class TestVisitor(TestHTMLVisitor):
         self.assertEqual('{{xref_csslength}}', str(ks[0]))
         self.assertEqual('{{cssxref("display")}}', str(ks[1]))
         self.assertEqual('<code>table-cell</code>', str(code))
+
+    def assert_compat_version(self, html, cls, version):
+        """Check that Compat* KumaScript is parsed correctly"""
+        parsed = kumascript_grammar['html'].parse(html)
+        out = self.visitor.visit(parsed)
+        self.assertEqual(len(out), 1)
+        ks = out[0]
+        self.assertIsInstance(ks, cls)
+        self.assertEqual(version, ks.version)
+
+    def test_compatchrome(self):
+        self.assert_compat_version(
+            '{{CompatChrome("10.0")}}', CompatChrome, '10.0')

--- a/mdn/tests/test_utils.py
+++ b/mdn/tests/test_utils.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 from datetime import date
 
 from mdn.utils import (
-    date_to_iso, end_of_line, is_new_id, join_content, slugify)
+    date_to_iso, end_of_line, format_version, is_new_id, join_content,
+    slugify)
 from .base import TestCase
 
 
@@ -24,6 +25,17 @@ class TestEndOfLine(TestCase):
     def test_multiple_line(self):
         line = 'This is a multi line\nSee, two lines'
         self.assertEqual(20, end_of_line(line, 2))
+
+
+class TestFormatVersion(TestCase):
+    def test_dotted(self):
+        self.assertEqual('1.0', format_version('1.0'))
+
+    def test_double_dotted(self):
+        self.assertEqual('1.0.1', format_version('1.0.1'))
+
+    def test_plain(self):
+        self.assertEqual('1.0', format_version('1'))
 
 
 class TestIsNewID(TestCase):

--- a/mdn/utils.py
+++ b/mdn/utils.py
@@ -22,6 +22,16 @@ def end_of_line(text, pos):
         return len(text)
 
 
+def format_version(version):
+    """Format a version to 1.0, 1.0.1, etc."""
+    if '.' in version:
+        return version
+    else:
+        assert version
+        assert int(version)
+        return version + '.0'
+
+
 def is_new_id(_id):
     """Detect if an ID signifies a new resource.
 


### PR DESCRIPTION
Generalize parsing of version numbers from ``{{Compat*}}`` macros such as ``{{CompatChrome}}``, ``{{CompatSafari}}``, etc., and add support for missing macros.  This will resolve over 1600 [unknown_kumascript](https://browsercompat.herokuapp.com/importer/issues/unknown_kumascript) issues in the new importer.