### PR TITLE
fix bug 1198912 - Allow {{SpecName}} in spec desc

### DIFF
--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -435,7 +435,7 @@ class SpecName(SpecKumaScript):
     min_args = 1
     max_args = 3
     arg_names = ['SpecKey', 'Anchor', 'AnchorName']
-    expected_scopes = set(('specification name',))
+    expected_scopes = set(('specification name', 'specification description'))
 
     def __init__(self, **kwargs):
         super(SpecName, self).__init__(**kwargs)

--- a/mdn/tests/test_specifications.py
+++ b/mdn/tests/test_specifications.py
@@ -380,7 +380,8 @@ class TestSpec2Visitor(TestCase):
             {'name': 'SpecName', 'args': ["HTML WHATWG"],
              'scope': 'specification maturity',
              'kumascript': '{{SpecName("HTML WHATWG")}}',
-             'expected_scopes': 'specification name'})]
+             'expected_scopes': (
+                'specification description or specification name')})]
         self.assert_spec2(html, None, issues)
         self.assertEqual(self.visitor.spec, None)
 


### PR DESCRIPTION
Convert {{SpecName('Name')}} to 'specification Name' in the specification description cell.  Fixes over 400 [unexpected_kumascript](https://browsercompat.herokuapp.com/importer/issues/unexpected_kumascript) issues.