### PR TITLE
bug 1198896 - Improve handling of <a> tags

### DIFF
--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -781,6 +781,8 @@ class KumaVisitor(BaseKumaVisitor):
         """Validate and cleanup <a> open tags."""
         actions = self._default_attribute_actions.copy()
         actions['href'] = 'must'
+        actions['title'] = 'drop'
+        actions['class'] = 'keep'
         converted = self._visit_open(node, children, actions)
 
         # Convert relative links to absolute links
@@ -789,6 +791,18 @@ class KumaVisitor(BaseKumaVisitor):
             href = attrs['href'].value
             if href and href[0] == '/':
                 attrs['href'].value = MDN_DOMAIN + href
+
+        # Drop class attribute, warning if unexpected
+        if 'class' in attrs:
+            class_attr = attrs.pop('class')
+            for value in class_attr.value.split():
+                if value in ('external', 'external-icon'):
+                    pass
+                else:
+                    self.add_issue(
+                        'unexpected_attribute', class_attr, node_type='a',
+                        ident='class', value=value,
+                        expected='the attribute href')
 
         return converted
 

--- a/mdn/specifications.py
+++ b/mdn/specifications.py
@@ -301,7 +301,7 @@ class SpecDescVisitor(KumaVisitor):
     This is the third column of the Specifications table.
     """
     scope = 'specification description'
-    _allowed_tags = ['br', 'code', 'td']
+    _allowed_tags = ['a', 'br', 'code', 'td']
 
     def __init__(self, **kwargs):
         super(SpecDescVisitor, self).__init__(**kwargs)

--- a/mdn/tests/test_compatibility.py
+++ b/mdn/tests/test_compatibility.py
@@ -980,11 +980,7 @@ class TestFootnoteVisitor(TestCase):
         expected = {
             '1': ('Compatibility data from <a href="http://caniuse.com">'
                   'caniuse.com</a>.', 0, 106)}
-        issue = (
-            'unexpected_attribute', 59, 85,
-            {'node_type': 'a', 'ident': 'title',
-             'value': 'http://caniuse.com', 'expected': u'the attribute href'})
-        self.assert_footnotes(footnote, expected, issues=[issue])
+        self.assert_footnotes(footnote, expected)
 
     def test_br_start(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/VRFieldOfViewReadOnly/downDegrees

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -669,3 +669,29 @@ class TestVisitor(TestHTMLVisitor):
     def test_compatsafari(self):
         self.assert_compat_version(
             '{{CompatSafari("2")}}', CompatSafari, '2.0')
+
+    def assert_a(self, html, converted, issues=None):
+        parsed = kumascript_grammar['html'].parse(html)
+        out = self.visitor.visit(parsed)
+        self.assertEqual(len(out), 1)
+        a = out[0]
+        self.assertEqual('a', a.tag)
+        self.assertEqual(converted, a.to_html())
+        self.assertEqual(issues or [], self.visitor.issues)
+
+    def test_a_missing(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/flex
+        issues = [
+            ('unexpected_attribute', 3, 13,
+             {'node_type': 'a', 'ident': 'name', 'value': 'bc1',
+              'expected': 'the attribute href'}),
+            ('missing_attribute', 0, 14, {'node_type': 'a', 'ident': 'href'})]
+        self.assert_a(
+            '<a name="bc1">[1]</a>', '<a>[1]</a>', issues=issues)
+
+    def test_a_MDN_relative(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/image
+        self.assert_a(
+            '<a href="/en-US/docs/Web/CSS/CSS3">CSS3</a>',
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS3">'
+             'CSS3</a>'))

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -695,3 +695,25 @@ class TestVisitor(TestHTMLVisitor):
             '<a href="/en-US/docs/Web/CSS/CSS3">CSS3</a>',
             ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS3">'
              'CSS3</a>'))
+
+    def test_a_external(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
+        self.assert_a(
+            ('<a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/'
+             'speechapi.html" class="external external-icon">Web Speech API'
+             '</a>'),
+            ('<a href="https://dvcs.w3.org/hg/speech-api/raw-file/tip/'
+             'speechapi.html">Web Speech API</a>'))
+
+    def test_a_bad_class(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagNameNS
+        self.assert_a(
+            ('<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=542185#c5"'
+             ' class="link-https"'
+             ' title="https://bugzilla.mozilla.org/show_bug.cgi?id=542185#c5">'
+             'comment from Henri Sivonen about the change</a>'),
+            ('<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=542185#c5"'
+             '>comment from Henri Sivonen about the change</a>'),
+            [('unexpected_attribute', 65, 83,
+              {'node_type': 'a', 'ident': 'class', 'value': 'link-https',
+               'expected': 'the attribute href'})])


### PR DESCRIPTION
* Convert MDN relative links to absolute links
* Silently drop ``title`` attributes, ``class=external``, and ``class=external-icon``.
* Allow <a> tags in specification description

Fixes about 100 [tag_dropped](https://browsercompat.herokuapp.com/importer/issues/tag_dropped) issues and 50 [unexpected_attribute](https://browsercompat.herokuapp.com/importer/issues/unexpected_attribute) issues.