### PR TITLE
Bug 1181140 - Handle cross-reference macros

### DIFF
--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -565,22 +565,23 @@ class DeprecatedInline(KnownKumaScript):
     expected_scopes = set(('compatibility feature',))
 
 
-class DOMxRef(KnownKumaScript):
+class DOMxRef(XRefBase):
     # https://developer.mozilla.org/en-US/docs/Template:domxref
     min_args = 1
     max_args = 2
     arg_names = ['DOMPath', 'DOMText']
     canonical_name = 'domxref'
-    expected_scopes = set(
-        ('specification description', 'compatibility feature', 'footnote'))
 
     def __init__(self, **kwargs):
         super(DOMxRef, self).__init__(**kwargs)
         self.dom_path = self.arg(0)
         self.dom_text = self.arg(1)
-
-    def to_html(self):
-        return '<code>{}</code>'.format(self.dom_text or self.dom_path)
+        path = self.dom_path.replace(' ', '_').replace('()', '')
+        if '.' in path and '..' not in path:
+            path = path.replace('.', '/')
+        path = path[0].upper() + path[1:]
+        self.url = '{}/Web/API/{}'.format(MDN_DOCS, path)
+        self.display = self.dom_text or self.dom_path
 
 
 class ExperimentalInline(KnownKumaScript):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -773,6 +773,12 @@ class XrefCSSLength(XrefCSSBase):
     xref_args = ('length', '&lt;length&gt;')
 
 
+class XrefCSSNumber(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssnumber
+    canonical_name = 'xref_cssnumber'
+    xref_args = ('number', '&lt;number&gt;')
+
+
 class XrefCSSPercentage(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_csspercentage
     canonical_name = 'xref_csspercentage'
@@ -867,6 +873,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'xref_csscolorvalue': XrefCSSColorValue,
         'xref_cssimage': XrefCSSImage,
         'xref_csslength': XrefCSSLength,
+        'xref_cssnumber': XrefCSSNumber,
         'xref_csspercentage': XrefCSSPercentage,
         'xref_cssstring': XrefCSSString,
     }

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -767,6 +767,12 @@ class XrefCSSImage(XrefCSSBase):
     xref_args = ('image', '&lt;image&gt;')
 
 
+class XrefCSSInteger(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssinteger
+    canonical_name = 'xref_cssinteger'
+    xref_args = ('integer', '&lt;integer&gt;')
+
+
 class XrefCSSLength(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_csslength
     canonical_name = 'xref_csslength'
@@ -872,6 +878,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'property_prefix': PropertyPrefix,
         'xref_csscolorvalue': XrefCSSColorValue,
         'xref_cssimage': XrefCSSImage,
+        'xref_cssinteger': XrefCSSInteger,
         'xref_csslength': XrefCSSLength,
         'xref_cssnumber': XrefCSSNumber,
         'xref_csspercentage': XrefCSSPercentage,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -767,6 +767,12 @@ class XrefCSSLength(XrefCSSBase):
     xref_args = ('length', '&lt;length&gt;')
 
 
+class XrefCSSPercentage(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_csspercentage
+    canonical_name = 'xref_csspercentage'
+    xref_args = ('percentage', '&lt;percentage&gt;')
+
+
 class BaseKumaVisitor(HTMLVisitor):
     """Extract HTML structure from a MDN Kuma raw fragment.
 
@@ -848,6 +854,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'property_prefix': PropertyPrefix,
         'xref_cssimage': XrefCSSImage,
         'xref_csslength': XrefCSSLength,
+        'xref_csspercentage': XrefCSSPercentage,
     }
 
     def _kumascript_lookup(self, name):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -755,6 +755,12 @@ class XrefCSSBase(CSSxRef):
         self.construct_crossref(*self.xref_args)
 
 
+class XrefCSSAngle(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssangle
+    canonical_name = 'xref_cssangle'
+    xref_args = ('angle', '&lt;angle&gt;')
+
+
 class XrefCSSColorValue(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_csscolorvalue
     canonical_name = 'xref_csscolorvalue'
@@ -882,6 +888,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'not_standard_inline': NotStandardInline,
         'obsolete_inline': ObsoleteInline,
         'property_prefix': PropertyPrefix,
+        'xref_cssangle': XrefCSSAngle,
         'xref_csscolorvalue': XrefCSSColorValue,
         'xref_cssgradient': XrefCSSGradient,
         'xref_cssimage': XrefCSSImage,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -779,6 +779,12 @@ class XrefCSSPercentage(XrefCSSBase):
     xref_args = ('percentage', '&lt;percentage&gt;')
 
 
+class XrefCSSString(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssstring
+    canonical_name = 'xref_cssstring'
+    xref_args = ('string', '&lt;string&gt;')
+
+
 class BaseKumaVisitor(HTMLVisitor):
     """Extract HTML structure from a MDN Kuma raw fragment.
 
@@ -862,6 +868,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'xref_cssimage': XrefCSSImage,
         'xref_csslength': XrefCSSLength,
         'xref_csspercentage': XrefCSSPercentage,
+        'xref_cssstring': XrefCSSString,
     }
 
     def _kumascript_lookup(self, name):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -669,6 +669,26 @@ class GeckoRelease(KnownKumaScript):
         return '(' + ' / '.join([rel + plus for rel in self.releases]) + ')'
 
 
+class HTMLAttrXRef(XRefBase):
+    # https://developer.mozilla.org/en-US/docs/Template:htmlattrxref
+    min_args = 1
+    max_args = 2
+    arg_names = ['attribute', 'element']
+    canonical_name = 'htmlattrxref'
+
+    def __init__(self, **kwargs):
+        super(HTMLAttrXRef, self).__init__(**kwargs)
+        self.attribute = self.arg(0)
+        self.element = self.arg(1)
+        self.text = self.arg(2)
+        if self.element:
+            self.url = '{}/Web/HTML/Element/{}'.format(MDN_DOCS, self.element)
+        else:
+            self.url = '{}/Web/HTML/Global_attributes'.format(MDN_DOCS)
+        self.url += '#attr-' + self.attribute.lower()
+        self.display = self.attribute.lower()
+
+
 class JSxRef(XRefBase):
     # https://developer.mozilla.org/en-US/docs/Template:jsxref
     min_args = 1
@@ -905,6 +925,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'event': Event,
         'experimental_inline': ExperimentalInline,
         'geckoRelease': GeckoRelease,
+        'htmlattrxref': HTMLAttrXRef,
         'jsxref': JSxRef,
         'non-standard_inline': NonStandardInline,
         'not_standard_inline': NotStandardInline,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -569,6 +569,20 @@ class DeprecatedInline(KnownKumaScript):
     expected_scopes = set(('compatibility feature',))
 
 
+class DOMException(XRefBase):
+    # https://developer.mozilla.org/en-US/docs/Template:exception
+    min_args = max_args = 1
+    arg_names = ['exception_id']
+    canonical_name = 'exception'
+
+    def __init__(self, **kwargs):
+        super(DOMException, self).__init__(**kwargs)
+        self.exception_id = self.arg(0)
+        self.url = '{}/Web/API/DOMException#{}'.format(
+            MDN_DOCS, self.exception_id)
+        self.display = self.exception_id
+
+
 class DOMxRef(XRefBase):
     # https://developer.mozilla.org/en-US/docs/Template:domxref
     min_args = 1
@@ -923,6 +937,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'deprecated_inline': DeprecatedInline,
         'domxref': DOMxRef,
         'event': Event,
+        'exception': DOMException,
         'experimental_inline': ExperimentalInline,
         'geckoRelease': GeckoRelease,
         'htmlattrxref': HTMLAttrXRef,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -523,7 +523,26 @@ class CSSBox(KnownKumaScript):
     expected_scopes = set()
 
 
-class CSSxRef(KnownKumaScript):
+class XRefBase(KnownKumaScript):
+    """Base class for cross-reference KumaScript"""
+    expected_scopes = set((
+        'compatibility feature', 'specification description', 'footnote'))
+
+    def __init__(self, **kwargs):
+        super(XRefBase, self).__init__(**kwargs)
+        self.url = None
+        self.display = "(unset)"
+        self.linked = self.scope in ('specification description', 'footnote')
+
+    def to_html(self):
+        if self.linked:
+            return '<a href="{}"><code>{}</code></a>'.format(
+                self.url, self.display)
+        else:
+            return '<code>{}</code>'.format(self.display)
+
+
+class CSSxRef(XRefBase):
     # https://developer.mozilla.org/en-US/docs/Template:cssxref
     min_args = 1
     max_args = 3
@@ -630,14 +649,12 @@ class GeckoRelease(KnownKumaScript):
         return '(' + ' / '.join([rel + plus for rel in self.releases]) + ')'
 
 
-class JSxRef(KnownKumaScript):
+class JSxRef(XRefBase):
     # https://developer.mozilla.org/en-US/docs/Template:jsxref
     min_args = 1
     max_args = 2
     arg_names = ['API name', 'display name']
     canonical_name = 'jsxref'
-    expected_scopes = set((
-        'compatibility feature', 'footnote', 'specification description'))
 
     def __init__(self, **kwargs):
         """
@@ -655,15 +672,7 @@ class JSxRef(KnownKumaScript):
             path_name = path_name.replace('.', '/')
         self.url = '{}/Web/JavaScript/Reference/Global_Objects/{}'.format(
             MDN_DOCS, path_name)
-        self.linked = self.scope in ('footnote', 'specification description')
-
-    def to_html(self):
-        display_name = self.display_name or self.api_name
-        if self.linked:
-            return '<a href="{}"><code>{}</code></a>'.format(
-                self.url, display_name)
-        else:
-            return "<code>{}</code>".format(display_name)
+        self.display = self.display_name or self.api_name
 
 
 class NonStandardInline(KnownKumaScript):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -755,6 +755,12 @@ class XrefCSSBase(CSSxRef):
         self.construct_crossref(*self.xref_args)
 
 
+class XrefCSSImage(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssimage
+    canonical_name = 'xref_cssimage'
+    xref_args = ('image', '&lt;image&gt;')
+
+
 class XrefCSSLength(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_csslength
     canonical_name = 'xref_csslength'
@@ -840,6 +846,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'not_standard_inline': NotStandardInline,
         'obsolete_inline': ObsoleteInline,
         'property_prefix': PropertyPrefix,
+        'xref_cssimage': XrefCSSImage,
         'xref_csslength': XrefCSSLength,
     }
 

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -548,15 +548,15 @@ class CSSxRef(XRefBase):
     max_args = 3
     arg_names = ['APIName', 'DisplayName', 'Anchor']
     canonical_name = 'cssxref'
-    expected_scopes = set(('specification description', 'footnote'))
 
     def __init__(self, **kwargs):
         super(CSSxRef, self).__init__(**kwargs)
         self.api_name = self.arg(0)
         self.display_name = self.arg(1)
-
-    def to_html(self):
-        return '<code>{}</code>'.format(self.display_name or self.api_name)
+        self.anchor = self.arg(2)
+        self.url = '{}/Web/CSS/{}{}'.format(
+            MDN_DOCS, self.api_name, self.anchor or '')
+        self.display = self.display_name or self.api_name
 
 
 class DeprecatedInline(KnownKumaScript):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -588,6 +588,21 @@ class DOMxRef(XRefBase):
         self.display = self.dom_text or self.dom_path
 
 
+class Event(XRefBase):
+    # https://developer.mozilla.org/en-US/docs/Template:event
+    min_args = 1
+    max_args = 2
+    arg_names = ['api_name', 'display_name']
+    canonical_name = 'event'
+
+    def __init__(self, **kwargs):
+        super(Event, self).__init__(**kwargs)
+        self.api_name = self.arg(0)
+        self.display_name = self.arg(1)
+        self.url = '{}/Web/Events/{}'.format(MDN_DOCS, self.api_name)
+        self.display = self.display_name or self.api_name
+
+
 class ExperimentalInline(KnownKumaScript):
     # https://developer.mozilla.org/en-US/docs/Template:experimental_inline
     canonical_name = 'experimental_inline'
@@ -887,6 +902,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'cssxref': CSSxRef,
         'deprecated_inline': DeprecatedInline,
         'domxref': DOMxRef,
+        'event': Event,
         'experimental_inline': ExperimentalInline,
         'geckoRelease': GeckoRelease,
         'jsxref': JSxRef,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -809,6 +809,12 @@ class XrefCSSString(XrefCSSBase):
     xref_args = ('string', '&lt;string&gt;')
 
 
+class XrefCSSVisual(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssvisual
+    canonical_name = 'xref_cssvisual'
+    xref_args = ('Media/Visual', '&lt;visual&gt;')
+
+
 class BaseKumaVisitor(HTMLVisitor):
     """Extract HTML structure from a MDN Kuma raw fragment.
 
@@ -897,6 +903,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'xref_cssnumber': XrefCSSNumber,
         'xref_csspercentage': XrefCSSPercentage,
         'xref_cssstring': XrefCSSString,
+        'xref_cssvisual': XrefCSSVisual,
     }
 
     def _kumascript_lookup(self, name):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -569,6 +569,25 @@ class DeprecatedInline(KnownKumaScript):
     expected_scopes = set(('compatibility feature',))
 
 
+class DOMEventXRef(XRefBase):
+    # https://developer.mozilla.org/en-US/docs/Template:domeventxref
+    min_args = max_args = 1
+    arg_names = ['api_name']
+    canonical_name = 'domeventxref'
+
+    def __init__(self, **kwargs):
+        """Initialize DOMEventXRef.
+
+        Only implements the subset of domeventxref used on current pages.
+        """
+        super(DOMEventXRef, self).__init__(**kwargs)
+        self.api_name = self.arg(0)
+        assert '()' not in self.api_name
+        self.url = '{}/DOM/DOM_event_reference/{}'.format(
+            MDN_DOCS, self.api_name)
+        self.display = self.api_name
+
+
 class DOMException(XRefBase):
     # https://developer.mozilla.org/en-US/docs/Template:exception
     min_args = max_args = 1
@@ -935,6 +954,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'cssbox': CSSBox,
         'cssxref': CSSxRef,
         'deprecated_inline': DeprecatedInline,
+        'domeventxref': DOMEventXRef,
         'domxref': DOMxRef,
         'event': Event,
         'exception': DOMException,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -531,11 +531,14 @@ class XRefBase(KnownKumaScript):
     def __init__(self, **kwargs):
         super(XRefBase, self).__init__(**kwargs)
         self.url = None
-        self.display = "(unset)"
+        self.display = None
         self.linked = self.scope in ('specification description', 'footnote')
 
     def to_html(self):
+        """Convert macro to link or plain text."""
+        assert self.display
         if self.linked:
+            assert self.url
             return '<a href="{}"><code>{}</code></a>'.format(
                 self.url, self.display)
         else:

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -755,6 +755,12 @@ class XrefCSSBase(CSSxRef):
         self.construct_crossref(*self.xref_args)
 
 
+class XrefCSSColorValue(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_csscolorvalue
+    canonical_name = 'xref_csscolorvalue'
+    xref_args = ('color_value', '&lt;color&gt;')
+
+
 class XrefCSSImage(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_cssimage
     canonical_name = 'xref_cssimage'
@@ -852,6 +858,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'not_standard_inline': NotStandardInline,
         'obsolete_inline': ObsoleteInline,
         'property_prefix': PropertyPrefix,
+        'xref_csscolorvalue': XrefCSSColorValue,
         'xref_cssimage': XrefCSSImage,
         'xref_csslength': XrefCSSLength,
         'xref_csspercentage': XrefCSSPercentage,

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -554,9 +554,13 @@ class CSSxRef(XRefBase):
         self.api_name = self.arg(0)
         self.display_name = self.arg(1)
         self.anchor = self.arg(2)
+        self.construct_crossref(
+            self.api_name, self.display_name, self.anchor)
+
+    def construct_crossref(self, api_name, display_name, anchor=None):
         self.url = '{}/Web/CSS/{}{}'.format(
-            MDN_DOCS, self.api_name, self.anchor or '')
-        self.display = self.display_name or self.api_name
+            MDN_DOCS, api_name, anchor or '')
+        self.display = display_name or api_name
 
 
 class DeprecatedInline(KnownKumaScript):
@@ -741,13 +745,20 @@ class WhyNoSpecBlock(HTMLInterval):
         return ""
 
 
-class XrefCSSLength(KnownKumaScript):
+class XrefCSSBase(CSSxRef):
+    """Base class for xref_cssXXX macros"""
+    min_args = max_args = 0
+    arg_names = []
+
+    def __init__(self, **kwargs):
+        super(XrefCSSBase, self).__init__(**kwargs)
+        self.construct_crossref(*self.xref_args)
+
+
+class XrefCSSLength(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_csslength
     canonical_name = 'xref_csslength'
-    expected_scopes = set(('specification description', 'footnote'))
-
-    def to_html(self):
-        return '<code>&lt;length&gt;</code>'
+    xref_args = ('length', '&lt;length&gt;')
 
 
 class BaseKumaVisitor(HTMLVisitor):

--- a/mdn/kumascript.py
+++ b/mdn/kumascript.py
@@ -761,6 +761,12 @@ class XrefCSSColorValue(XrefCSSBase):
     xref_args = ('color_value', '&lt;color&gt;')
 
 
+class XrefCSSGradient(XrefCSSBase):
+    # https://developer.mozilla.org/en-US/docs/Template:xref_cssgradient
+    canonical_name = 'xref_cssgradient'
+    xref_args = ('gradient', '&lt;gradient&gt;')
+
+
 class XrefCSSImage(XrefCSSBase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_cssimage
     canonical_name = 'xref_cssimage'
@@ -877,6 +883,7 @@ class BaseKumaVisitor(HTMLVisitor):
         'obsolete_inline': ObsoleteInline,
         'property_prefix': PropertyPrefix,
         'xref_csscolorvalue': XrefCSSColorValue,
+        'xref_cssgradient': XrefCSSGradient,
         'xref_cssimage': XrefCSSImage,
         'xref_cssinteger': XrefCSSInteger,
         'xref_csslength': XrefCSSLength,

--- a/mdn/tests/test_compatibility.py
+++ b/mdn/tests/test_compatibility.py
@@ -863,7 +863,11 @@ class TestFootnoteVisitor(TestCase):
 
     def test_kumascript_cssxref(self):
         footnotes = '<p>[1] Use {{cssxref("-moz-border-image")}}</p>'
-        expected = {'1': ('Use <code>-moz-border-image</code>', 0, 47)}
+        expected = {
+            '1': (
+                'Use <a href="https://developer.mozilla.org/en-US/docs/Web/'
+                'CSS/-moz-border-image"><code>-moz-border-image</code></a>',
+                0, 47)}
         self.assert_footnotes(footnotes, expected)
 
     def test_unknown_kumascriptscript(self):

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -10,7 +10,7 @@ from mdn.kumascript import (
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
     CompatOpera, CompatOperaMobile, CompatSafari, CompatUnknown,
     CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline,
-    ExperimentalInline, GeckoRelease, KumaHTMLElement, KnownKumaScript,
+    ExperimentalInline, GeckoRelease, JSxRef, KumaHTMLElement, KnownKumaScript,
     KumaScript, KumaVisitor, NonStandardInline, NotStandardInline,
     PropertyPrefix, Spec2, SpecName, UnknownKumaScript, WebkitBug,
     WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
@@ -457,6 +457,87 @@ class TestGeckoRelease(TestCase):
         ks = GeckoRelease(raw=raw, args=["33.0+"], scope='footnote')
         expected = "(Firefox 33.0+ / Thunderbird 33.0+ / SeaMonkey 2.30+)"
         self.assertEqual(ks.to_html(), expected)
+
+
+class TestJSxRef(TestCase):
+    # https://developer.mozilla.org/en-US/docs/Template:jsxref
+    def test_standard(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global
+        raw = '{{jsxref("RegExp")}}'
+        ks = JSxRef(
+            raw=raw, args=['RegExp'], scope='specification description')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
+             '/Reference/Global_Objects/RegExp"><code>RegExp</code></a>'))
+        self.assertFalse(ks.issues)
+        self.assertEqual(text_type(ks), raw)
+
+    def test_display_name(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments
+        raw = '{{jsxref("Functions/arguments", "arguments")}}'
+        ks = JSxRef(
+            raw=raw, args=["Functions/arguments", "arguments"],
+            scope='specification description')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
+             '/Reference/Global_Objects/Functions/arguments"><code>arguments'
+             '</code></a>'))
+
+    def test_feature_name(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD
+        raw = '{{jsxref("Float32x4", "SIMD.Float32x4")}}'
+        ks = JSxRef(
+            raw=raw, args=["Float32x4", "SIMD.Float32x4"],
+            scope='compatibility feature')
+        self.assertEqual(ks.to_html(), '<code>SIMD.Float32x4</code>')
+
+    def test_footnote(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/Blob
+        raw = '{{jsxref("Array/slice", "Array.slice()")}}'
+        ks = JSxRef(
+            raw=raw, args=["Array/slice", "Array.slice()"], scope='footnote')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
+             '/Reference/Global_Objects/Array/slice"><code>Array.slice()'
+             '</code></a>'))
+
+    def test_prototype(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+        raw = '{{jsxref("Array.prototype.lastIndexOf", "lastIndexOf")}}'
+        ks = JSxRef(
+            raw=raw, args=["Array.prototype.lastIndexOf", "lastIndexOf"],
+            scope='specification description')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
+             '/Reference/Global_Objects/Array/lastIndexOf"><code>lastIndexOf'
+             '</code></a>'))
+
+    def test_dotted_function(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
+        raw = '{{jsxref("Math.log10()", "log10()")}}'
+        ks = JSxRef(
+            raw=raw, args=["Math.log10()", "log10()"],
+            scope='specification description')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
+             '/Reference/Global_Objects/Math/log10"><code>log10()'
+             '</code></a>'))
+
+    def test_global_object(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
+        raw = '{{jsxref("Global_Objects/null", "null")}}'
+        ks = JSxRef(
+            raw=raw, args=["Global_Objects/null", "null"],
+            scope='specification description')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
+             '/Reference/Global_Objects/null"><code>null</code></a>'))
 
 
 class TestNonStandardInline(TestCase):

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -9,7 +9,7 @@ from mdn.kumascript import (
     Bug, CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
     CompatOpera, CompatOperaMobile, CompatSafari, CompatUnknown,
-    CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline,
+    CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline, Event,
     ExperimentalInline, GeckoRelease, JSxRef, KumaHTMLElement, KnownKumaScript,
     KumaScript, KumaVisitor, NonStandardInline, NotStandardInline,
     PropertyPrefix, Spec2, SpecName, UnknownKumaScript, WebkitBug,
@@ -449,6 +449,27 @@ class TestDOMxRef(TestCase):
             ks.to_html(),
             ('<a href="https://developer.mozilla.org/en-US/docs/Web/API/'
              'Window/alert"><code>window.alert()</code></a>'))
+
+
+class TestEvent(TestCase):
+    # https://developer.mozilla.org/en-US/docs/Template:event
+
+    def test_feature_name(self):
+        # No current compat pages
+        raw = '{{event("close")}}'
+        ks = Event(raw=raw, args=['close'], scope='compatibility feature')
+        self.assertEqual(ks.to_html(), '<code>close</code>')
+        self.assertFalse(ks.issues)
+        self.assertEqual(text_type(ks), raw)
+
+    def test_footnote(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/DeviceLightEvent/value
+        raw = '{{event("devicelight")}}'
+        ks = Event(raw=raw, args=['devicelight'], scope='footnote')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/Events/'
+             'devicelight"><code>devicelight</code></a>'))
 
 
 class TestExperimentalInline(TestCase):

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -407,7 +407,8 @@ class TestDOMxRef(TestCase):
     def test_standard(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/CharacterData
         raw = '{{domxref("ChildNode")}}'
-        ks = DOMxRef(raw=raw, args=['ChildNode'], scope=self.scope)
+        ks = DOMxRef(
+            raw=raw, args=['ChildNode'], scope='compatibility feature')
         self.assertEqual(ks.to_html(), '<code>ChildNode</code>')
         self.assertFalse(ks.issues)
         self.assertEqual(text_type(ks), raw)
@@ -417,7 +418,28 @@ class TestDOMxRef(TestCase):
         raw = '{{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}'
         args = ['CustomEvent.CustomEvent', 'CustomEvent()']
         ks = DOMxRef(raw=raw, args=args, scope=self.scope)
-        self.assertEqual(ks.to_html(), '<code>CustomEvent()</code>')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/API/'
+             'CustomEvent/CustomEvent"><code>CustomEvent()</code></a>'))
+
+    def test_space(self):
+        # No current pages, but in macro definition
+        raw = '{{domxref("Notifications API")}}'
+        ks = DOMxRef(raw=raw, args=['Notifications API'], scope=self.scope)
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/API/'
+             'Notifications_API"><code>Notifications API</code></a>'))
+
+    def test_parens_dot_caps(self):
+        # https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsershowmodalprompt
+        raw = '{{domxref("window.alert()")}}'
+        ks = DOMxRef(raw=raw, args=['window.alert()'], scope=self.scope)
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/API/'
+             'Window/alert"><code>window.alert()</code></a>'))
 
 
 class TestExperimentalInline(TestCase):

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -9,11 +9,11 @@ from mdn.kumascript import (
     Bug, CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
     CompatOpera, CompatOperaMobile, CompatSafari, CompatUnknown,
-    CompatVersionUnknown, CompatibilityTable, DOMException, DOMxRef,
-    DeprecatedInline, Event, ExperimentalInline, GeckoRelease, HTMLAttrXRef,
-    JSxRef, KumaHTMLElement, KnownKumaScript, KumaScript, KumaVisitor,
-    NonStandardInline, NotStandardInline, PropertyPrefix, Spec2, SpecName,
-    UnknownKumaScript, WebkitBug, WhyNoSpecBlock, XrefCSSLength,
+    CompatVersionUnknown, CompatibilityTable, DOMEventXRef, DOMException,
+    DOMxRef, DeprecatedInline, Event, ExperimentalInline, GeckoRelease,
+    HTMLAttrXRef, JSxRef, KumaHTMLElement, KnownKumaScript, KumaScript,
+    KumaVisitor, NonStandardInline, NotStandardInline, PropertyPrefix, Spec2,
+    SpecName, UnknownKumaScript, WebkitBug, WhyNoSpecBlock, XrefCSSLength,
     kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
@@ -406,6 +406,22 @@ class TestDeprecatedInline(TestCase):
         raw = '{{deprecated_inline}}'
         ks = DeprecatedInline(raw=raw, scope='compatibility feature')
         self.assertEqual(ks.to_html(), '')
+        self.assertFalse(ks.issues)
+        self.assertEqual(text_type(ks), raw)
+
+
+class TestDOMEventXRef(TestCase):
+    # https://developer.mozilla.org/en-US/docs/Template:domeventxref
+
+    def test_footnote(self):
+        # https://developer.mozilla.org/en-US/docs/Web/Events/compositionupdate
+        raw = '{{domeventxref("compositionstart")}}'
+        ks = DOMEventXRef(raw=raw, args=['compositionstart'], scope='footnote')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/DOM/'
+             'DOM_event_reference/compositionstart"><code>compositionstart'
+             '</code></a>'))
         self.assertFalse(ks.issues)
         self.assertEqual(text_type(ks), raw)
 

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -9,11 +9,12 @@ from mdn.kumascript import (
     Bug, CSSBox, CSSxRef, CompatAndroid, CompatChrome, CompatGeckoDesktop,
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
     CompatOpera, CompatOperaMobile, CompatSafari, CompatUnknown,
-    CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline, Event,
-    ExperimentalInline, GeckoRelease, HTMLAttrXRef, JSxRef, KumaHTMLElement,
-    KnownKumaScript, KumaScript, KumaVisitor, NonStandardInline,
-    NotStandardInline, PropertyPrefix, Spec2, SpecName, UnknownKumaScript,
-    WebkitBug, WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
+    CompatVersionUnknown, CompatibilityTable, DOMException, DOMxRef,
+    DeprecatedInline, Event, ExperimentalInline, GeckoRelease, HTMLAttrXRef,
+    JSxRef, KumaHTMLElement, KnownKumaScript, KumaScript, KumaVisitor,
+    NonStandardInline, NotStandardInline, PropertyPrefix, Spec2, SpecName,
+    UnknownKumaScript, WebkitBug, WhyNoSpecBlock, XrefCSSLength,
+    kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
 from .test_html import TestVisitor as TestHTMLVisitor
@@ -405,6 +406,21 @@ class TestDeprecatedInline(TestCase):
         raw = '{{deprecated_inline}}'
         ks = DeprecatedInline(raw=raw, scope='compatibility feature')
         self.assertEqual(ks.to_html(), '')
+        self.assertFalse(ks.issues)
+        self.assertEqual(text_type(ks), raw)
+
+
+class TestDOMException(TestCase):
+    # https://developer.mozilla.org/en-US/docs/Template:exception
+
+    def test_footnote(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
+        raw = '{{exception("TypeError")}}'
+        ks = DOMException(raw=raw, args=['TypeError'], scope='footnote')
+        self.assertEqual(
+            ks.to_html(),
+            '<a href="https://developer.mozilla.org/en-US/docs/Web/API/'
+            'DOMException#TypeError"><code>TypeError</code></a>')
         self.assertFalse(ks.issues)
         self.assertEqual(text_type(ks), raw)
 

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -627,12 +627,20 @@ class TestWhyNoSpecBlock(TestCase):
 
 class TestXrefCSSLength(TestCase):
     # https://developer.mozilla.org/en-US/docs/Template:xref_csslength
-    def test_standard(self):
+    def test_feature_name(self):
         raw = '{{xref_csslength()}}'
-        ks = XrefCSSLength(raw=raw, scope='footnote')
+        ks = XrefCSSLength(raw=raw, scope='compatibility feature')
         self.assertEqual('<code>&lt;length&gt;</code>', ks.to_html())
         self.assertEqual([], ks.issues)
         self.assertEqual(text_type(ks), '{{xref_csslength}}')
+
+    def test_footnote(self):
+        raw = '{{xref_csslength()}}'
+        ks = XrefCSSLength(raw=raw, scope='footnote')
+        self.assertEqual(
+            '<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/'
+            'length"><code>&lt;length&gt;</code></a>',
+            ks.to_html())
 
 
 class TestGrammar(TestHTMLGrammar):

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -10,10 +10,10 @@ from mdn.kumascript import (
     CompatGeckoFxOS, CompatGeckoMobile, CompatIE, CompatNightly, CompatNo,
     CompatOpera, CompatOperaMobile, CompatSafari, CompatUnknown,
     CompatVersionUnknown, CompatibilityTable, DOMxRef, DeprecatedInline, Event,
-    ExperimentalInline, GeckoRelease, JSxRef, KumaHTMLElement, KnownKumaScript,
-    KumaScript, KumaVisitor, NonStandardInline, NotStandardInline,
-    PropertyPrefix, Spec2, SpecName, UnknownKumaScript, WebkitBug,
-    WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
+    ExperimentalInline, GeckoRelease, HTMLAttrXRef, JSxRef, KumaHTMLElement,
+    KnownKumaScript, KumaScript, KumaVisitor, NonStandardInline,
+    NotStandardInline, PropertyPrefix, Spec2, SpecName, UnknownKumaScript,
+    WebkitBug, WhyNoSpecBlock, XrefCSSLength, kumascript_grammar)
 from .base import TestCase
 from .test_html import TestGrammar as TestHTMLGrammar
 from .test_html import TestVisitor as TestHTMLVisitor
@@ -590,6 +590,39 @@ class TestJSxRef(TestCase):
             ks.to_html(),
             ('<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript'
              '/Reference/Global_Objects/null"><code>null</code></a>'))
+
+
+class TestHTMLAttrXRef(TestCase):
+    # https://developer.mozilla.org/en-US/docs/Template:htmlattrxref
+
+    def test_feature_name(self):
+        # No current compat pages
+        raw = '{{htmlattrxref("style")}}'
+        ks = HTMLAttrXRef(
+            raw=raw, args=['style'], scope='compatibility feature')
+        self.assertEqual(ks.to_html(), '<code>style</code>')
+        self.assertFalse(ks.issues)
+        self.assertEqual(text_type(ks), raw)
+
+    def test_spec_desc_without_element(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
+        raw = '{{htmlattrxref("class")}}'
+        ks = HTMLAttrXRef(
+            raw=raw, args=['class'], scope='specification description')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/'
+             'Global_attributes#attr-class"><code>class</code></a>'))
+
+    def test_footnote_with_element(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/Element
+        raw = '{{htmlattrxref("sandbox", "iframe")}}'
+        ks = HTMLAttrXRef(
+            raw=raw, args=['sandbox', 'iframe'], scope='footnote')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/'
+             'Element/iframe#attr-sandbox"><code>sandbox</code></a>'))
 
 
 class TestNonStandardInline(TestCase):

--- a/mdn/tests/test_kumascript.py
+++ b/mdn/tests/test_kumascript.py
@@ -377,17 +377,26 @@ class TestCSSxRef(TestCase):
         ks = CSSxRef(raw=raw, args=['z-index'], scope=self.scope)
         self.assertEqual(ks.api_name, 'z-index')
         self.assertIsNone(ks.display_name)
-        self.assertEqual(ks.to_html(), '<code>z-index</code>')
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/'
+             'z-index"><code>z-index</code></a>'))
         self.assertEqual(ks.issues, [])
         self.assertEqual(text_type(ks), raw)
 
     def test_display_override(self):
         raw = '{{cssxref("the-foo", "foo")}}'
         ks = CSSxRef(raw=raw, args=['the-foo', 'foo'], scope=self.scope)
-        self.assertEqual(ks.api_name, 'the-foo')
-        self.assertEqual(ks.display_name, 'foo')
-        self.assertEqual(ks.to_html(), '<code>foo</code>')
-        self.assertEqual(ks.issues, [])
+        self.assertEqual(
+            ks.to_html(),
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/'
+             'the-foo"><code>foo</code></a>'))
+
+    def test_feature_name(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/attr
+        raw = '{{cssxref("content")}}'
+        ks = CSSxRef(raw=raw, args=['content'], scope='compatibility feature')
+        self.assertEqual(ks.to_html(), '<code>content</code>')
 
 
 class TestDeprecatedInline(TestCase):

--- a/mdn/tests/test_specifications.py
+++ b/mdn/tests/test_specifications.py
@@ -445,7 +445,9 @@ class TestSpecDescVisitor(TestCase):
         expected = [
             'Add the', '<code>&lt;length&gt;</code>',
             'value and allows it to be applied to element with a',
-            '<code>display</code>', 'type of', '<code>table-cell</code>', '.']
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/'
+             'display"><code>display</code></a>'),
+            'type of', '<code>table-cell</code>', '.']
         self.assert_specdesc(html, expected, [])
 
     def test_kumascript_spec2(self):

--- a/mdn/tests/test_specifications.py
+++ b/mdn/tests/test_specifications.py
@@ -443,7 +443,9 @@ class TestSpecDescVisitor(TestCase):
             ' applied to element with a {{ cssxref("display") }} type of'
             ' <code>table-cell</code>.</td>')
         expected = [
-            'Add the', '<code>&lt;length&gt;</code>',
+            'Add the',
+            ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/'
+             'length"><code>&lt;length&gt;</code></a>'),
             'value and allows it to be applied to element with a',
             ('<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/'
              'display"><code>display</code></a>'),


### PR DESCRIPTION
Switch cross-reference macros to generate MDN links in text areas, and plain text in feature names.  Add handling for cross-reference macros used in compatibility data, responsible for about 150 [unknown_kumascript](https://browsercompat.herokuapp.com/importer/issues/unknown_kumascript) issues.