### PR TITLE
fix bug 1198907 - ignore <br> in feature names

### DIFF
--- a/mdn/compatibility.py
+++ b/mdn/compatibility.py
@@ -8,7 +8,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.six import text_type
 from parsimonious.grammar import Grammar
 
-from .html import HnElement, HTMLElement, HTMLSelfClosingElement, HTMLText
+from .html import HnElement, HTMLElement, HTMLText
 from .kumascript import (
     CompatAndroid, CompatGeckoDesktop, CompatGeckoFxOS, CompatGeckoMobile,
     CompatNightly, CompatNo, CompatUnknown, CompatVersionUnknown,
@@ -471,7 +471,8 @@ class CompatFeatureVisitor(CompatBaseVisitor):
         processed = super(CompatFeatureVisitor, self).process(
             cls, node, **kwargs)
         if isinstance(processed, HTMLElement):
-            if processed.tag == 'td':
+            tag = processed.tag
+            if tag == 'td':
                 processed.drop_tag = True
                 if self.outer_td:
                     self.add_issue(
@@ -631,6 +632,9 @@ class CompatSupportVisitor(CompatBaseVisitor):
                 self.commit_support_and_version()
             elif tag == 'code':
                 self.inline_texts.append((processed, processed.to_html()))
+            elif tag == 'br':
+                if self.version.get('version'):
+                    self.commit_support_and_version()
         elif isinstance(processed, CellVersion):
             self.set_version(processed.version, processed)
         elif isinstance(processed, CompatVersionUnknown):
@@ -674,10 +678,6 @@ class CompatSupportVisitor(CompatBaseVisitor):
         elif isinstance(processed, HTMLText):
             if processed.cleaned:
                 self.inline_texts.append((processed, processed.cleaned))
-        elif (isinstance(processed, HTMLSelfClosingElement) and
-              processed.tag == 'br'):
-            if self.version.get('version'):
-                self.commit_support_and_version()
         return processed
 
     version_re = re.compile(r"((\d+(\.\d+)*)|current|nightly)$")
@@ -810,8 +810,8 @@ class CompatFootnoteVisitor(CompatBaseVisitor):
                 self.gather_content(processed)
             elif tag == 'pre':
                 self.process_pre(processed)
-        elif isinstance(processed, HTMLSelfClosingElement):
-            processed.drop_tag = True
+            elif tag in ('br', 'hr'):
+                processed.drop_tag = True
         return processed
 
     def process_pre(self, pre_element):

--- a/mdn/compatibility.py
+++ b/mdn/compatibility.py
@@ -447,7 +447,7 @@ class CompatFeatureVisitor(CompatBaseVisitor):
     This is the first column of the compatibility table.
     """
     scope = 'compatibility feature'
-    _allowed_tags = ['code', 'td']
+    _allowed_tags = ['code', 'td', 'br']
 
     def __init__(self, parent_feature, **kwargs):
         """Initialize a CompatFeatureVisitor.
@@ -458,7 +458,6 @@ class CompatFeatureVisitor(CompatBaseVisitor):
         super(CompatFeatureVisitor, self).__init__(**kwargs)
         self.parent_feature = parent_feature
         self.name = None
-        self.name_bits = []
         self.feature_id = None
         self.canonical = False
         self.experimental = False
@@ -479,6 +478,8 @@ class CompatFeatureVisitor(CompatBaseVisitor):
                         'tag_dropped', self.outer_td.open_tag, tag='td',
                         scope=self.scope)
                 self.outer_td = processed
+            elif tag == 'br':
+                processed.drop_tag = True  # Silently drop <br> tags
         elif isinstance(processed, Footnote):
             self.add_issue('footnote_feature', processed)
         elif isinstance(processed, DeprecatedInline):

--- a/mdn/tests/test_compatibility.py
+++ b/mdn/tests/test_compatibility.py
@@ -307,9 +307,7 @@ class TestFeatureVisitor(TestCase):
         feature_id = '_support for contain and cover'
         name = 'Support for <code>contain</code> and <code>cover</code>'
         slug = 'web-css-background-size_support_for_contain_and_co'
-        issue = ('tag_dropped', 16, 20,
-                 {'scope': 'compatibility feature', 'tag': 'br'})
-        self.assert_feature(cell, feature_id, name, slug, issues=[issue])
+        self.assert_feature(cell, feature_id, name, slug)
 
     def test_code_sequence(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/display
@@ -427,10 +425,9 @@ class TestFeatureVisitor(TestCase):
         feature_id = '_cross-origin resource sharing'
         name = 'Cross-Origin Resource Sharing'
         slug = 'web-css-background-size_cross-origin_resource_shar'
-        issues = [
-            ('tag_dropped', 4, 38, {'tag': 'a', 'scope': self.scope}),
-            ('tag_dropped', 71, 75, {'tag': 'br', 'scope': self.scope})]
-        self.assert_feature(cell, feature_id, name, slug, issues=issues)
+        issue = (
+            'tag_dropped', 4, 38, {'tag': 'a', 'scope': self.scope})
+        self.assert_feature(cell, feature_id, name, slug, issues=[issue])
 
     def test_p(self):
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const

--- a/mdn/tests/test_html.py
+++ b/mdn/tests/test_html.py
@@ -6,8 +6,7 @@ from django.utils.six import text_type
 
 from mdn.html import (
     HTMLAttribute, HTMLAttributes, HTMLCloseTag, HTMLElement, HTMLInterval,
-    HTMLOpenTag, HTMLBaseTag, HTMLSelfClosingElement, HTMLText, HTMLVisitor,
-    HnElement, html_grammar)
+    HTMLOpenTag, HTMLBaseTag, HTMLText, HTMLVisitor, HnElement, html_grammar)
 from .base import TestCase
 
 
@@ -189,21 +188,6 @@ class TestHTMLCloseTag(TestCase):
         self.assertEqual(raw, text_type(tag))
 
 
-class TestHTMLSelfClosingElement(TestCase):
-    def test_to_html(self):
-        raw = '<br>'
-        attrs = HTMLAttributes()
-        element = HTMLSelfClosingElement(raw=raw, tag='br', attributes=attrs)
-        self.assertEqual(raw, element.to_html())
-
-    def test_to_html_drop_tag(self):
-        raw = '<br>'
-        attrs = HTMLAttributes()
-        element = HTMLSelfClosingElement(
-            raw=raw, tag='br', attributes=attrs, drop_tag=True)
-        self.assertEqual('', element.to_html())
-
-
 class TestHTMLElement(TestCase):
     def test_str(self):
         raw = '<p class="first">A Text Element</p>'
@@ -237,6 +221,20 @@ class TestHTMLElement(TestCase):
             raw=raw, open_tag=p_open_tag, close_tag=p_close_tag,
             children=[text1, strong_elem, text2])
         self.assertEqual('A Text Element', p_elem.to_text())
+
+    def test_br_to_html(self):
+        raw = '<br>'
+        attrs = HTMLAttributes()
+        open_tag = HTMLOpenTag(raw=raw, tag='br', attributes=attrs)
+        element = HTMLElement(raw=raw, open_tag=open_tag)
+        self.assertEqual(raw, element.to_html())
+
+    def test_br_to_html_drop_tag(self):
+        raw = '<br>'
+        attrs = HTMLAttributes()
+        open_tag = HTMLOpenTag(raw=raw, tag='br', attributes=attrs)
+        element = HTMLElement(raw=raw, open_tag=open_tag, drop_tag=True)
+        self.assertEqual('', element.to_html())
 
 
 class TestGrammar(TestCase):


### PR DESCRIPTION
Fixes 46 [tag_dropped](https://browsercompat.herokuapp.com/importer/issues/tag_dropped) issues.  Also, refactored handling of self-closing elements so that all HTML elements are handled the same way.