### PR TITLE
Give up importing huge pages

### DIFF
--- a/tools/import_mdn.py
+++ b/tools/import_mdn.py
@@ -55,11 +55,11 @@ class ImportMDNData(Tool):
                 except RequestException as exception:
                     if attempt < max_attempt:
                         self.logger.error("%s", exception)
-                        attempt += 1
                         self.logger.info('Pausing 5 seconds...')
                         time.sleep(5)
                     else:
-                        raise
+                        self.logger.info('Giving up on %s.', uri)
+                    attempt += 1
                 else:
                     counts[import_type] += 1
                     if import_type in ('new', 'reset'):


### PR DESCRIPTION
Some pages have the lethal combination of lots of compat data, many translations, and lots of data issues.  Because we don't have the async infrastructure in place, processing these pages takes longer than the requests timeout. This change still gives up after 3 tries, but continues to the next page rather than failing the import.