### PR TITLE
Update mock to 1.3.0

### DIFF
--- a/bcauth/tests.py
+++ b/bcauth/tests.py
@@ -59,7 +59,7 @@ class TestProvidersMediaJS(TestCase):
         self.mocked_get_list.return_value = [mock_provider]
         actual = providers_media_js(self.context)
         self.assertEqual(fake_js, actual)
-        mock_provider.media_js.assertCalledOnce(self.context['request'])
+        mock_provider.media_js.assert_called_once_with(self.context['request'])
 
 
 class TestProviderLoginUrl(TestCase):

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -139,7 +139,7 @@ class TestFeaturePageCreateView(TestCase):
         self.assertEqual(feature_page.feature_id, self.feature.id)
         expected = 'http://testserver' + feature_page.get_absolute_url()
         self.assertEqual(expected, response["LOCATION"])
-        mock_task.assertCalledOnce(feature_page.id)
+        mock_task.assert_called_once_with(feature_page.id)
 
 
 class TestFeaturePageDetailView(TestCase):
@@ -242,7 +242,7 @@ class TestFeaturePageReParseView(TestCase):
         response = self.client.post(self.url)
         dest_url = reverse('feature_page_detail', kwargs={'pk': self.fp.pk})
         self.assertRedirects(response, dest_url)
-        mocked_parse.assertCalledOnce(self.fp.pk)
+        mocked_parse.assert_called_once_with(self.fp.pk)
         fp = FeaturePage.objects.get(id=self.fp.id)
         self.assertEqual(fp.STATUS_PARSING, fp.status)
 
@@ -267,7 +267,7 @@ class TestFeaturePageResetView(TestCase):
         response = self.client.post(self.url)
         dest_url = reverse('feature_page_detail', kwargs={'pk': self.fp.pk})
         self.assertRedirects(response, dest_url)
-        mocked_crawl.assertCalledOnce(self.fp.pk)
+        mocked_crawl.assert_called_once_with(self.fp.pk)
         fp = FeaturePage.objects.get(id=self.fp.id)
         self.assertEqual(fp.STATUS_STARTING, fp.status)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ nose==1.3.7
 django-nose==1.4.1
 
 # Test Mocking, included in Python 3.3
-mock==1.0.1
+mock==1.3.0
 
 # WSGI runner, used in Heroku
 gunicorn==19.3.0

--- a/webplatformcompat/tests/test_viewsets.py
+++ b/webplatformcompat/tests/test_viewsets.py
@@ -213,10 +213,11 @@ class TestGenericViewset(APITestCase):
         })
         url = reverse('browser-detail', kwargs={'pk': browser.pk})
         url += '?changeset=%s' % changeset.pk
+        mock_update.reset_mock()
         response = self.client.put(
             url, data=data, content_type="application/vnd.api+json")
         self.assertEqual(200, response.status_code, response.data)
-        mock_update.assertNotCalled()
+        mock_update.assert_not_called()
 
     def test_put_as_json(self):
         """If content is application/json, put is full put"""
@@ -274,7 +275,7 @@ class TestGenericViewset(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(204, response.status_code, response.content)
         self.assertFalse(Browser.objects.filter(pk=browser.pk).exists())
-        mock_update.assertNotCalled()
+        mock_update.assert_not_called()
 
 
 class TestFeatureViewSet(APITestCase):


### PR DESCRIPTION
Updating mock from 1.0.1 to 1.3.0 exposed that the tests of mocked calls were not using the assertion methods, and thus were not testing anything.

Part of getting system ready for [bug 1153288](https://bugzilla.mozilla.org/show_bug.cgi?id=1153288), with a goal of [bumping all requirements](https://github.com/mdn/browsercompat/tree/bump_requirements_1153288) and [getting to green](https://requires.io/github/mdn/browsercompat/requirements/?branch=bump_requirements_1153288)