### PR TITLE
Update django_extensions to 1.5.7

### DIFF
--- a/mdn/migrations/0008_switch_modified_to_datetimefield.py
+++ b/mdn/migrations/0008_switch_modified_to_datetimefield.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mdn', '0007_expand_status_choices'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='featurepage',
+            name='modified',
+            field=models.DateTimeField(help_text='Last modification time', auto_now=True, db_index=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pagemeta',
+            name='crawled',
+            field=models.DateTimeField(help_text='Time when the content was retrieved', auto_now=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='translatedcontent',
+            name='crawled',
+            field=models.DateTimeField(help_text='Time when the content was retrieved', auto_now=True),
+            preserve_default=True,
+        ),
+    ]

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -257,11 +257,13 @@ Enjoy.
 
 class TestPageMetaModel(TestCase):
     def setUp(self):
-        fp = FeaturePage(
+        feature = self.create(Feature)
+        fp = FeaturePage.objects.create(
+            feature=feature,
             url="https://developer.mozilla.org/en-US/docs/Web/CSS/display",
-            feature_id=666,
             status=FeaturePage.STATUS_PARSED)
-        self.meta = PageMeta(page=fp, path="/de/docs/Web/CSS/display")
+        self.meta = PageMeta.objects.create(
+            page=fp, path="/de/docs/Web/CSS/display")
 
     def test_str(self):
         expected = u'/de/docs/Web/CSS/display retrieved 0\xa0minutes ago'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-filter==0.11.0
 
 # Django extensions
 six==1.9.0
-django-extensions==1.5.5
+django-extensions==1.5.7
 
 # JSON API interfaces for Django REST Framework
 git+git://github.com/jwhitlock/drf-json-api@v0.1d#egg=drf-json-api

--- a/webplatformcompat/history.py
+++ b/webplatformcompat/history.py
@@ -8,8 +8,6 @@ from django.conf import settings
 from django.db import models
 from django.http import HttpResponseBadRequest
 from django.utils.timezone import now
-from django_extensions.db.fields import (
-    CreationDateTimeField, ModificationDateTimeField)
 
 from simple_history.middleware import (
     HistoryRequestMiddleware as BaseHistoryRequestMiddleware)
@@ -48,8 +46,8 @@ class Changeset(models.Model):
         'supports', 'versions',
     ]
 
-    created = CreationDateTimeField()
-    modified = ModificationDateTimeField()
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
     user = models.ForeignKey(user_model, related_name="changesets")
     closed = models.BooleanField(
         help_text="Is the changeset closed to new changes?",

--- a/webplatformcompat/migrations/0015_switch_created_modified_to_datetimefield.py
+++ b/webplatformcompat/migrations/0015_switch_created_modified_to_datetimefield.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0014_disallow_blank_versions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='changeset',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='changeset',
+            name='modified',
+            field=models.DateTimeField(auto_now=True),
+            preserve_default=True,
+        ),
+    ]

--- a/webplatformcompat/tests/test_cache.py
+++ b/webplatformcompat/tests/test_cache.py
@@ -67,8 +67,9 @@ class TestCache(TestCase):
 
     def test_changeset_v1_serializer(self):
         created = datetime(2014, 10, 29, 8, 57, 21, 806744, UTC)
-        changeset = self.create(Changeset, user=self.user, created=created)
-        Changeset.objects.filter(pk=changeset.pk).update(modified=created)
+        changeset = self.create(Changeset, user=self.user)
+        Changeset.objects.filter(pk=changeset.pk).update(
+            created=created, modified=created)
         changeset = Changeset.objects.get(pk=changeset.pk)
         out = self.cache.changeset_v1_serializer(changeset)
         expected = {


### PR DESCRIPTION
Updating django_extensions from 1.5.5 to 1.5.7 included a change to ``ModificationDateTimeField`` and the ``CreationDateTimeField`` to make them more like the Django standard ``DateTimeField``.  This required a migration and code changes, so I took the opportunity to switch to Django's ``DateTimeField`` entirely.  It behaves differently, setting times on the DB rather than in Python, requiring some changes.

This is part of getting ready for [bug 1153288](https://bugzilla.mozilla.org/show_bug.cgi?id=1153288), with a goal of [bumping all requirements](https://github.com/mdn/browsercompat/tree/bump_requirements_1153288) and [getting to green](https://requires.io/github/mdn/browsercompat/requirements/?branch=bump_requirements_1153288)