### PR TITLE
Update django-allauth to 0.23.0

### DIFF
--- a/bcauth/helpers.py
+++ b/bcauth/helpers.py
@@ -6,7 +6,7 @@ This file is loaded by jingo and must be named helpers.py
 from allauth.account.utils import user_display
 from allauth.socialaccount import providers
 from allauth.socialaccount.templatetags.socialaccount import \
-    get_social_accounts
+    get_social_accounts, get_providers
 
 from jinja2 import contextfunction
 from jingo import register
@@ -56,3 +56,4 @@ def provider_login_url(
 
 register.function(user_display)
 register.function(get_social_accounts)
+register.function(get_providers)

--- a/bcauth/templates/account/login.jinja2
+++ b/bcauth/templates/account/login.jinja2
@@ -1,11 +1,12 @@
 {% extends "account/base.jinja2" %}
 {% from "socialaccount/snippets/provider_list.jinja2" import list %}
+{% set providers = get_providers() %}
 
 {% block head_title %}{{ _("Sign In") }}{% endblock %}
 {% block body_title %}{{ _("Sign In") }}{% endblock %}
 
 {% block content %}
-{% if socialaccount.providers  %}
+{% if providers %}
 <p>{% trans site_name=site.name %}Please sign in with one
 of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
 for a {{site_name}} account and sign in below:{% endtrans %}</p>
@@ -13,7 +14,7 @@ for a {{site_name}} account and sign in below:{% endtrans %}</p>
 <div class="socialaccount_ballot">
 
   <ul class="socialaccount_providers">
-    {{ list(request, socialaccount.providers, process='login') }}
+    {{ list(request, providers, process='login') }}
   </ul>
 
   <div class="login-or">{{ _('or') }}</div>
@@ -40,7 +41,7 @@ for a {{site_name}} account and sign in below:{% endtrans %}</p>
 {% endblock %}
 
 {% block body_js_extra %}
-{% if socialaccount.providers  %}
+{% if providers  %}
 {{ providers_media_js() }}
 {% endif %}
 {% endblock %}

--- a/bcauth/templates/socialaccount/connections.jinja2
+++ b/bcauth/templates/socialaccount/connections.jinja2
@@ -1,5 +1,6 @@
 {% extends "account/profile.jinja2" %}
 {% from "socialaccount/snippets/provider_list.jinja2" import list %}
+{% set providers = get_providers() %}
 
 {% block head_subtitle %} - {{ _("Account Connections") }}{% endblock %}
 {% block body_title %}{{ _("Account Connections") }}{% endblock %}
@@ -48,13 +49,13 @@
 <h2>{{ _('Add a 3rd Party Account') }}</h2>
 
 <ul class="socialaccount_providers">
-{{ list(request, socialaccount.providers, process='connect') }}
+{{ list(request, providers, process='connect') }}
 </ul>
 
 {% endblock %}
 
 {% block body_js_extra %}
-{% if socialaccount.providers  %}
+{% if providers  %}
 {{ providers_media_js() }}
 {% endif %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,4 +84,4 @@ git+git://github.com/erikrose/parsimonious@20863d86a#egg=parsimonious
 requests==2.7.0
 oauthlib==0.7.2
 requests-oauthlib==0.5.0
-django-allauth==0.20.0
+django-allauth==0.23.0

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -146,8 +146,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.contrib.auth.context_processors.auth",
     "django.core.context_processors.request",
     "django.contrib.messages.context_processors.messages",
-    "allauth.account.context_processors.account",
-    "allauth.socialaccount.context_processors.socialaccount",
 )
 
 # Email settings


### PR DESCRIPTION
django-allauth 0.23.0 drops the context processors, which changes how the providers list is accessed.