### PR TITLE
Update Django REST Framework to 3.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Jinja2==2.8
 jingo==0.7.1
 
 # Django REST Framework.
-djangorestframework==3.1.3
+djangorestframework==3.2.4
 Markdown==2.6.2
 django-filter==0.11.0
 

--- a/webplatformcompat/migrations/0016_feature_sections_allow_blank.py
+++ b/webplatformcompat/migrations/0016_feature_sections_allow_blank.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sortedm2m.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0015_switch_created_modified_to_datetimefield'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='feature',
+            name='sections',
+            field=sortedm2m.fields.SortedManyToManyField(help_text=None, related_name='features', to='webplatformcompat.Section', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/webplatformcompat/models.py
+++ b/webplatformcompat/models.py
@@ -83,7 +83,8 @@ class Feature(MPTTModel):
     parent = TreeForeignKey(
         'self', help_text="Feature set that contains this feature",
         null=True, blank=True, related_name='children')
-    sections = SortedManyToManyField('Section', related_name='features')
+    sections = SortedManyToManyField(
+        'Section', related_name='features', blank=True)
     objects = CachingManager()
     # history = HistoricalFeatureRecords()  # Registered below
 

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -153,11 +153,6 @@ class FeatureSerializer(HistoricalModelSerializer):
             'sections', 'supports', 'parent', 'children',
             'history_current', 'history')
         read_only_fields = ('supports',)
-        extra_kwargs = {
-            'sections': {
-                'default': []
-            }
-        }
 
 
 class MaturitySerializer(HistoricalModelSerializer):

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -88,8 +88,8 @@ class FeatureViewSet(ModelViewSet):
 
     def filter_queryset(self, queryset):
         qs = super(FeatureViewSet, self).filter_queryset(queryset)
-        if 'parent' in self.request.QUERY_PARAMS:
-            filter_value = self.request.QUERY_PARAMS['parent']
+        if 'parent' in self.request.query_params:
+            filter_value = self.request.query_params['parent']
             if not filter_value:
                 qs = qs.filter(parent=None)
         return qs


### PR DESCRIPTION
DRF 3.2 makes a couple of changes that required code changes:
* In a many-to-many field, blank=False (default) now means that a blank result is not allowed.  Switch to blank=True to allow empty, remove non-standard extra args to feature.sections, and make a migration.
* ``request.QUERY_PARAMS`` changed to ``request.query_params``.

This is part of getting ready for [bug 1153288](https://bugzilla.mozilla.org/show_bug.cgi?id=1153288), with a goal of [bumping all requirements](https://github.com/mdn/browsercompat/tree/bump_requirements_1153288) and [getting to green](https://requires.io/github/mdn/browsercompat/requirements/?branch=bump_requirements_1153288).  Next is the last one, updates to Django 1.8