### PR TITLE
bug 1208238 - Handle unicode in CSV

### DIFF
--- a/mdn/html.py
+++ b/mdn/html.py
@@ -234,6 +234,7 @@ class HTMLText(HTMLInterval):
     (\s|                # Any whitespace, or
      (<\s*br\s*/?>)|    # A variant of <br>, or
      \xa0|              # Unicode non-breaking space, or
+     \ufeff|            # Unicode BOM
      (\&nbsp;)          # HTML nbsp character
     )+                  # One or more in a row
     ''')

--- a/mdn/tests/test_html.py
+++ b/mdn/tests/test_html.py
@@ -33,6 +33,10 @@ class TestHTMLText(TestCase):
         text = HTMLText(raw='\nSome Text\n')
         self.assertEqual('Some Text', text.to_text())
 
+    def test_bom_removed(self):
+        text = HTMLText(raw='BOM -> \ufeff')
+        self.assertEqual('BOM ->', text.to_text())
+
 
 class TestHTMLBaseTag(TestCase):
     def test_str(self):

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -340,6 +340,19 @@ class TestIssuesDetailCSV(CSVTestCase):
         ]
         self.assert_csv_response(url, expected)
 
+    def test_get_unicode(self):
+        text = "Pas avant les éléments en-ligne"
+        self.issue.params = {"text": text}
+        self.issue.save()
+
+        url = reverse('issues_detail_csv', kwargs={'slug': 'inline-text'})
+        full_url = 'http://testserver/importer/{}'.format(self.fp.pk)
+        expected = [
+            'MDN Slug,Import URL,Source Start,Source End,text',
+            'docs/Web/CSS/float,{},10,20,{}'.format(full_url, text),
+        ]
+        self.assert_csv_response(url, expected)
+
 
 class TestIssuesSummaryCSV(CSVTestCase):
     def test_get(self):

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -2,7 +2,6 @@
 from collections import Counter
 from json import loads
 from math import floor
-import csv
 
 from django import forms
 from django.contrib.auth.decorators import user_passes_test
@@ -15,6 +14,7 @@ from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView
 from django.views.generic.edit import CreateView, FormMixin, UpdateView
+import unicodecsv as csv
 
 from .models import FeaturePage, Issue, ISSUES, SEVERITIES, validate_mdn_url
 from .tasks import start_crawl, parse_page

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,3 +84,6 @@ requests==2.7.0
 oauthlib==1.0.3
 requests-oauthlib==0.5.0
 django-allauth==0.23.0
+
+# Unicode-aware CSVs
+unicodecsv==0.14.1


### PR DESCRIPTION
This PR:
- Encodes all unicode strings as UTF-8 before passing to CSV writer
- Converts the BOM character (0xFEFF) to spaces in ``HTMLText``

The BOM character appears in [Web/CSS/-webkit-mask](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-mask) (In "Basic Support" row, between ``<td>{{CompatNo}}﻿`` and ``</td>``, see [importer](https://browsercompat.herokuapp.com/importer/3951)), and was causing Python's ASCII-only CSV writer to choke.  The issue CSV can now include unicode, and ``-webkit-mask`` doesn't warn about the BOM as inline text.