### PR TITLE
Treat "Basic support" rows as describing the feature

### DIFF
--- a/mdn/compatibility.py
+++ b/mdn/compatibility.py
@@ -62,6 +62,7 @@ class CompatSectionExtractor(Extractor):
         <tbody>
           <tr><th>Feature</th><th>Chrome</th></tr>
           <tr><td>Basic support</td><td>1.0 [1]</td></tr>
+          <tr><td><code>contain</code></td><td>3.0</td></tr>
         </tbody>
       </table>
     </div>

--- a/mdn/data.py
+++ b/mdn/data.py
@@ -62,6 +62,11 @@ class Data(object):
         """
         nname = normalize_name(name)
 
+        # Treat "Basic Support" rows as parent feature
+        if nname.lower() == 'basic support':
+            return self.FeatureParams(
+                parent_feature, parent_feature.id, parent_feature.slug)
+
         # Initialize subfeature data as needed
         if parent_feature.id not in self.subfeature_data:
             subfeatures = {}

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -351,7 +351,8 @@ class ScrapedViewFeature(object):
                 feature_content = self.new_feature(feature_entry)
             else:
                 feature_content = self.load_feature(feature_entry['id'])
-            self.add_resource_if_new('features', feature_content)
+            if str(feature_entry['id']) != str(self.feature.id):
+                self.add_resource_if_new('features', feature_content)
             self.compat_table_supports.setdefault(
                 text_type(feature_content['id']), OrderedDict())
 

--- a/mdn/tests/base.py
+++ b/mdn/tests/base.py
@@ -55,9 +55,9 @@ class TestCase(BaseTestCase):
         ('Feature', 'web-css-background-size'): {
             '_req': {'parent': ('Feature', 'web-css')},
             'name': '{"zxx": "background-size"}'},
-        ('Feature', 'web-css-background-size-basic_support'): {
+        ('Feature', 'web-css-background-size-contain_and_cover'): {
             '_req': {'parent': ('Feature', 'web-css-background-size')},
-            'name': '{"en": "Basic support"}'},
+            'name': '{"en": "<code>contain</code> and <code>cover</code>"}'},
         ('Browser', 'chrome'): {'name': '{"en": "Chrome"}'},
         ('Browser', 'firefox'): {'name': '{"en": "Firefox"}'},
         ('Version', ('chrome', '1.0')): {},

--- a/mdn/tests/test_compatibility.py
+++ b/mdn/tests/test_compatibility.py
@@ -46,7 +46,7 @@ class TestCompatSectionExtractor(TestCase):
                 '<h2 id="Browser_compatibility">Browser compatibility</h2>'),
             pre_table=pre_table or '<div>{{CompatibilityTable}}</div>',
             browser=browser or 'Firefox',
-            feature=feature or 'Basic support',
+            feature=feature or '<code>contain</code> and <code>cover</code>',
             support=support or '1.0',
             after_table=after_table or '')
 
@@ -60,11 +60,12 @@ class TestCompatSectionExtractor(TestCase):
             'versions': [{
                 'browser': browser_id, 'id': version_id, 'version': '1.0'}],
             'features': [{
-                'id': '_basic support', 'name': 'Basic support',
-                'slug': 'web-css-background-size_basic_support'}],
+                'id': '_contain and cover',
+                'name': '<code>contain</code> and <code>cover</code>',
+                'slug': 'web-css-background-size_contain_and_cover'}],
             'supports': [{
-                'feature': '_basic support',
-                'id': '__basic support-%s' % version_id,
+                'feature': '_contain and cover',
+                'id': '__contain and cover-%s' % version_id,
                 'support': 'yes', 'version': version_id}]}
 
     def assert_extract(
@@ -90,9 +91,9 @@ class TestCompatSectionExtractor(TestCase):
         expected['versions'][0] = {
             'id': '_Fire-1.0', 'version': '1.0', 'browser': '_Fire'}
         expected['supports'][0] = {
-            'id': u'__basic support-_Fire-1.0',
+            'id': u'__contain and cover-_Fire-1.0',
             'support': 'yes',
-            'feature': '_basic support',
+            'feature': '_contain and cover',
             'version': '_Fire-1.0'}
         issue = ('unknown_browser', 205, 218, {'name': 'Fire'})
         self.assert_extract(html, [expected], issues=[issue])
@@ -111,7 +112,7 @@ class TestCompatSectionExtractor(TestCase):
             after_table="<p>[1] This is a footnote.</p>")
         expected = self.get_default_compat_div()
         expected['supports'][0]['footnote'] = 'This is a footnote.'
-        expected['supports'][0]['footnote_id'] = ('1', 292, 295)
+        expected['supports'][0]['footnote_id'] = ('1', 322, 325)
         self.assert_extract(html, [expected])
 
     def test_footnote_mismatch(self):
@@ -119,11 +120,11 @@ class TestCompatSectionExtractor(TestCase):
             support="1.0 [1]",
             after_table="<p>[2] Oops, footnote ID is wrong.</p>")
         expected = self.get_default_compat_div()
-        expected['supports'][0]['footnote_id'] = ('1', 292, 295)
-        footnotes = {'2': ('Oops, footnote ID is wrong.', 344, 382)}
+        expected['supports'][0]['footnote_id'] = ('1', 322, 325)
+        footnotes = {'2': ('Oops, footnote ID is wrong.', 374, 412)}
         issues = [
-            ('footnote_missing', 292, 295, {'footnote_id': '1'}),
-            ('footnote_unused', 344, 382, {'footnote_id': '2'})]
+            ('footnote_missing', 322, 325, {'footnote_id': '1'}),
+            ('footnote_unused', 374, 412, {'footnote_id': '2'})]
         self.assert_extract(
             html, [expected], footnotes=footnotes, issues=issues)
 
@@ -135,7 +136,7 @@ class TestCompatSectionExtractor(TestCase):
             "<td>1.0</td>", "<td>1.0</td><td>{{CompatUnknown()}}</td>")
         self.assertTrue('CompatUnknown' in html)
         expected = self.get_default_compat_div()
-        issue = ('extra_cell', 296, 324, {})
+        issue = ('extra_cell', 326, 354, {})
         self.assert_extract(html, [expected], issues=[issue])
 
     def test_compat_mobile_table(self):
@@ -144,7 +145,10 @@ class TestCompatSectionExtractor(TestCase):
   <table class="compat-table">
     <tbody>
       <tr><th>Feature</th><th>Safari Mobile</th></tr>
-      <tr><td>Basic support</td><td>1.0 [1]</td></tr>
+      <tr>
+        <td><code>contain</code> and <code>cover</code></td>
+        <td>1.0 [1]</td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -161,9 +165,9 @@ class TestCompatSectionExtractor(TestCase):
                 'slug': '_Safari Mobile',
             }],
             'features': [{
-                'id': '_basic support',
-                'name': 'Basic support',
-                'slug': 'web-css-background-size_basic_support',
+                'id': '_contain and cover',
+                'name': '<code>contain</code> and <code>cover</code>',
+                'slug': 'web-css-background-size_contain_and_cover',
             }],
             'versions': [{
                 'id': '_Safari Mobile-1.0',
@@ -171,15 +175,15 @@ class TestCompatSectionExtractor(TestCase):
                 'browser': '_Safari Mobile',
             }],
             'supports': [{
-                'id': '__basic support-_Safari Mobile-1.0',
-                'feature': '_basic support',
+                'id': '__contain and cover-_Safari Mobile-1.0',
+                'feature': '_contain and cover',
                 'support': 'yes',
                 'version': '_Safari Mobile-1.0',
                 'footnote': "It's really supported.",
-                'footnote_id': ('1', 503, 506),
+                'footnote_id': ('1', 581, 584),
             }],
         }
-        issue = ('unknown_browser', 435, 457, {'name': 'Safari Mobile'})
+        issue = ('unknown_browser', 465, 487, {'name': 'Safari Mobile'})
         self.assert_extract(
             html, [expected_desktop, expected_mobile], issues=[issue])
 
@@ -193,21 +197,22 @@ class TestCompatSectionExtractor(TestCase):
         self.assert_extract(html, [expected], issues=[issue])
 
     def test_feature_issue(self):
-        html = self.construct_html(feature='Basic support [1]')
+        html = self.construct_html(
+            feature='<code>contain</code> and <code>cover</code> [1]')
         expected = self.get_default_compat_div()
-        issue = ('footnote_feature', 271, 274, {})
+        issue = ('footnote_feature', 300, 304, {})
         self.assert_extract(html, [expected], issues=[issue])
 
     def test_support_issue(self):
         html = self.construct_html(support="1.0 (or earlier)")
         expected = self.get_default_compat_div()
-        issue = ('inline_text', 292, 304, {'text': '(or earlier)'})
+        issue = ('inline_text', 322, 334, {'text': '(or earlier)'})
         self.assert_extract(html, [expected], issues=[issue])
 
     def test_footnote_issue(self):
         html = self.construct_html(after_table="<p>Here's some text.</p>")
         expected = self.get_default_compat_div()
-        issue = ('footnote_no_id', 340, 364, {})
+        issue = ('footnote_no_id', 370, 394, {})
         self.assert_extract(html, [expected], issues=[issue])
 
     def test_table_div_wraps_h3(self):
@@ -218,8 +223,8 @@ class TestCompatSectionExtractor(TestCase):
         expected = self.get_default_compat_div()
         issues = [
             ('skipped_content', 58, 126, {}),
-            ('footnote_gap', 404, 408, {}),
-            ('footnote_no_id', 388, 403, {})]
+            ('footnote_gap', 434, 438, {}),
+            ('footnote_no_id', 418, 433, {})]
         self.assert_extract(html, [expected], issues=issues)
 
     def test_support_colspan_exceeds_table_width(self):
@@ -227,7 +232,7 @@ class TestCompatSectionExtractor(TestCase):
         html = self.construct_html()
         html = html.replace("<td>1.0", '<td colspan="2">1.0')
         expected = self.get_default_compat_div()
-        issue = ('cell_out_of_bounds', 284, 308, {})
+        issue = ('cell_out_of_bounds', 314, 338, {})
         self.assert_extract(html, [expected], issues=[issue])
 
 
@@ -248,7 +253,7 @@ class TestFootnote(TestCase):
 
 class TestFeatureGrammar(TestCase):
     def test_standard(self):
-        text = '<td>Basic Support</td>'
+        text = '<td>contain and cover</td>'
         parsed = compat_feature_grammar['html'].parse(text)
         assert parsed
 
@@ -617,7 +622,7 @@ class TestSupportVisitor(TestCase):
         version = self.get_instance('Version', ('firefox', '1.0'))
         self.set_browser(version.browser)
         feature = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
         self.feature_id = feature.id
         support = self.create(Support, version=version, feature=feature)
         self.assert_support(

--- a/mdn/tests/test_data.py
+++ b/mdn/tests/test_data.py
@@ -47,6 +47,11 @@ class TestLookupFeatureParams(TestDataBase):
             new_params = self.data.lookup_feature_params(self.parent, name)
         self.assertEqual(params, new_params)
 
+    def test_feature_params_basic_support(self):
+        self.assert_feature_params(
+            'Basic Support', self.parent, self.parent.id,
+            'web-css-background-size')
+
     def test_feature_params_new(self):
         self.assert_feature_params(
             'Row Feature', None, '_row feature',

--- a/mdn/tests/test_data.py
+++ b/mdn/tests/test_data.py
@@ -49,14 +49,14 @@ class TestLookupFeatureParams(TestDataBase):
 
     def test_feature_params_new(self):
         self.assert_feature_params(
-            'Basic Support', None, '_basic support',
-            'web-css-background-size_basic_support')
+            'Row Feature', None, '_row feature',
+            'web-css-background-size_row_feature')
 
     def test_feature_params_match(self):
         match = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
         self.assert_feature_params(
-            'Basic Support', match, match.id, match.slug)
+            match.name['en'], match, match.id, match.slug)
 
     def test_feature_params_match_canonical(self):
         match = self.create(
@@ -111,7 +111,7 @@ class TestLookupSupportId(TestDataBase):
         super(TestLookupSupportId, self).setUp()
         self.version = self.get_instance('Version', ('firefox', 'current'))
         self.feature = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
 
     def assert_new_support_id(self, version_id, feature_id):
         support_id = self.data.lookup_support_id(version_id, feature_id)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -13,6 +13,9 @@ from .base import TestCase
 
 
 class BaseTestCase(TestCase):
+    def setUp(self):
+        self.feature = self.get_instance('Feature', 'web-css-background-size')
+
     def get_sample_specs(self):
         sample_spec_section = """\
 <h2 id="Specifications" name="Specifications">Specifications</h2>
@@ -50,7 +53,10 @@ class BaseTestCase(TestCase):
  <table class="compat-table">
   <tbody>
    <tr><th>Feature</th><th>Firefox (Gecko)</th></tr>
-   <tr><td>Basic support</td><td>{{CompatGeckoDesktop("1")}}</td></tr>
+   <tr>
+    <td><code>contain</code> and <code>cover</code></td>
+    <td>{{CompatGeckoDesktop("1")}}</td>
+   </tr>
   </tbody>
  </table>
 </div>
@@ -65,18 +71,19 @@ class BaseTestCase(TestCase):
             'versions': [{
                 'browser': browser_id, 'id': version_id, 'version': '1.0'}],
             'features': [{
-                'id': '_basic support', 'name': 'Basic support',
-                'slug': 'web-css-background-size_basic_support'}],
+                'id': '_contain and cover',
+                'name': '<code>contain</code> and <code>cover</code>',
+                'slug': 'web-css-background-size_contain_and_cover'}],
             'supports': [{
-                'feature': '_basic support',
-                'id': '__basic support-%s' % version_id,
+                'feature': '_contain and cover',
+                'id': '__contain and cover-%s' % version_id,
                 'support': 'yes', 'version': version_id}]}]
         return sample_compat_section, expected_compat
 
 
 class TestPageExtractor(BaseTestCase):
     def setUp(self):
-        self.feature = self.get_instance('Feature', 'web-css-background-size')
+        super(TestPageExtractor, self).setUp()
         self.visitor = PageVisitor()
 
     def assert_extract(
@@ -144,7 +151,7 @@ class TestPageExtractor(BaseTestCase):
         page = (
             sample_compat_section +
             '<h3 id="Gecko Gecko">Gecko Note</h3>\n<p>A note</p>')
-        issues = [('skipped_h3', 310, 346, {'h3': 'Gecko Note'})]
+        issues = [('skipped_h3', 354, 390, {'h3': 'Gecko Note'})]
         self.assert_extract(page, compat=expected_compat, issues=issues)
 
     def test_div_wrapped(self):
@@ -163,9 +170,6 @@ class TestPageExtractor(BaseTestCase):
 
 
 class TestScrape(BaseTestCase):
-    def setUp(self):
-        self.feature = self.get_instance('Feature', 'web-css-background-size')
-
     def assertScrape(self, page, specs, issues):
         actual = scrape_page(page, self.feature)
         self.assertEqual(actual['locale'], 'en')
@@ -459,11 +463,12 @@ class TestScrapedViewFeature(FeaturePageTestCase):
 
     def test_load_feature(self):
         feature = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
         view = ScrapedViewFeature(self.page, self.empty_scrape())
         feature_content = view.load_feature(feature.id)
         expected = {
-            'id': str(feature.id), 'name': {'en': 'Basic support'},
+            'id': str(feature.id),
+            'name': {'en': '<code>contain</code> and <code>cover</code>'},
             'slug': feature.slug, 'mdn_uri': None, 'obsolete': False,
             'stable': True, 'standardized': True, 'experimental': False,
             'links': {
@@ -488,13 +493,15 @@ class TestScrapedViewFeature(FeaturePageTestCase):
 
     def test_new_feature(self):
         feature_entry = {
-            'id': '_feature', 'name': 'Basic support',
-            'slug': 'web-css-background-size_basic_support'}
+            'id': '_feature',
+            'name': '<code>contain</code> and <code>cover</code>',
+            'slug': 'web-css-background-size_contain_and_cover'}
         view = ScrapedViewFeature(self.page, self.empty_scrape())
         feature_content = view.new_feature(feature_entry)
         expected = {
-            'id': '_feature', 'name': {'en': 'Basic support'},
-            'slug': 'web-css-background-size_basic_support',
+            'id': '_feature',
+            'name': {'en': '<code>contain</code> and <code>cover</code>'},
+            'slug': 'web-css-background-size_contain_and_cover',
             'mdn_uri': None, 'obsolete': False, 'stable': True,
             'standardized': True, 'experimental': False,
             'links': {
@@ -521,7 +528,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
     def test_load_support(self):
         version = self.get_instance('Version', ('firefox', '1.0'))
         feature = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
         support = self.create(Support, version=version, feature=feature)
         view = ScrapedViewFeature(self.page, self.empty_scrape())
         support_content = view.load_support(support.id)
@@ -609,7 +616,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
     def test_load_compat_table_new_resources(self):
         browser_id = '_Firefox (Gecko)'
         version_id = '_Firefox-1.0'
-        feature_id = '_basic_support'
+        feature_id = '_contain_and_cover'
         support_id = '_%s-%s' % (feature_id, version_id)
         scraped_data = self.empty_scrape()
         scraped_table = {
@@ -620,8 +627,9 @@ class TestScrapedViewFeature(FeaturePageTestCase):
             'versions': [{
                 'id': version_id, 'browser': browser_id, 'version': '1.0'}],
             'features': [{
-                'id': feature_id, 'name': 'Basic support',
-                'slug': 'web-css-background-size_basic_support'}],
+                'id': feature_id,
+                'name': '<code>contain</code> and <code>cover</code>',
+                'slug': 'web-css-background-size_contain_and_cover'}],
             'supports': [{
                 'id': support_id, 'feature': feature_id, 'version': version_id,
                 'support': 'yes'}]}
@@ -647,7 +655,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         version = self.get_instance('Version', ('firefox', '1.0'))
         browser = version.browser
         feature = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
         support = self.create(Support, version=version, feature=feature)
         browser_id = str(browser.id)
         version_id = str(version.id)
@@ -686,7 +694,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         version = self.get_instance('Version', ('firefox', '1.0'))
         browser = version.browser
         feature = self.get_instance(
-            'Feature', 'web-css-background-size-basic_support')
+            'Feature', 'web-css-background-size-contain_and_cover')
         browser_id = str(browser.id)
         version_id = str(version.id)
         feature_id = str(feature.id)

--- a/webplatformcompat/static/js/webplatformcompat.js
+++ b/webplatformcompat/static/js/webplatformcompat.js
@@ -137,7 +137,7 @@ window.WPC = {
     },
     generate_browser_tables: function (resources, lang) {
         var a, backlink, browser, browserCnt, browserId, browserIdx,
-            browserMap, feature, featureId, note, noteArray,
+            browserMap, feature, featureId, featureName, note, noteArray,
             noteCnt, noteDiv, noteId, noteIdx, noteNum,
             noteSup, idPrefix, nosupport, panel, prefix,
             releaseUri, span1, span2, support, supportCnt, supportId,
@@ -209,13 +209,18 @@ window.WPC = {
                 tbody = document.createElement('tbody');
                 supportMap = resources.meta.compat_table.supports;
                 for (featureId in supportMap) {
-                    if (supportMap.hasOwnProperty(featureId) &&
-                            featureId !== resources.data.id) {
+                    if (supportMap.hasOwnProperty(featureId)) {
                         browserMap = supportMap[featureId];
-                        feature = resources.features[featureId];
+                        if (featureId === resources.data.id) {
+                            feature = resources.data;
+                            featureName = this.trans_span(this.strings['Basic support'], lang);
+                        } else {
+                            feature = resources.features[featureId];
+                            featureName = this.trans_span(feature.name, lang);
+                        }
                         tr = document.createElement('tr');
                         td = document.createElement('td');
-                        td.appendChild(this.trans_span(feature.name, lang));
+                        td.appendChild(featureName);
                         if (feature.experimental) {
                             span1 = document.createElement('span');
                             span1.setAttribute('class', 'glyphicon glyphicon-fire');
@@ -389,4 +394,14 @@ window.WPC = {
         }
         return null;
     },
+    strings: {
+        'Basic support': {
+            'de': 'Grundlegende Unterstützung',
+            'en': 'Basic support',
+            'es': 'Soporte básico',
+            'fr': 'Support de base',
+            'ja': '基本サポート',
+            'pt-BR': 'Suporte básico',
+        },
+    }
 };

--- a/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
@@ -42,6 +42,17 @@
 
 <i>No specifications</i>
 {% endif %}
+{%- set strings = {
+        'Basic support': {
+            'de': 'Grundlegende Unterstützung',
+            'en': 'Basic support',
+            'es': 'Soporte básico',
+            'fr': 'Support de base',
+            'ja': '基本サポート',
+            'pt-BR': 'Suporte básico',
+        },
+    }
+%}
 
 <h2>Browser compatibility</h2>
 {%- for tab in meta['compat_table']['tabs'] %}
@@ -62,11 +73,16 @@
   </thead>
   <tbody>
     {%- for feature_id, browser_map in meta['compat_table']['supports'].items() %}
-    {%- if feature_id != data['id'] %}
+    {%- if feature_id == data['id'] %}
+    {%- set feature = data %}
+    {%- set feature_name = trans_span(strings['Basic support']) %}
+    {%- else %}
     {%- set feature = collection['features'][feature_id] %}
+    {%- set feature_name = trans_span(feature.name) %}
+    {%- endif %}
 
     <tr>
-      <td>{{trans_span(feature.name)}}</td>
+      <td>{{feature_name}}</td>
       {%- for browser_id in tab['browsers'] %}
         {%- set browser = collection['browsers'][browser_id] %}
         {%- set supports = browser_map[browser_id] %}
@@ -110,7 +126,6 @@
       {%- endfor %}
 
     </tr>
-    {%- endif %}
     {%- endfor %}
 
   </tbody>

--- a/webplatformcompat/tests/test_view_serializers.py
+++ b/webplatformcompat/tests/test_view_serializers.py
@@ -462,9 +462,6 @@ class TestViewFeatureViewSet(APITestCase):
                 'en': ('https://developer.mozilla.org/'
                        'en-US/docs/Web/HTML/Element/address')},
             slug='html-element-address', name={'zxx': 'address'})
-        feature_row_191 = self.create(
-            Feature, parent=feature_816, slug='html-address',
-            name={'en': 'Basic support'})
 
         browser_chrome_1 = self.create(
             Browser, slug='chrome', name={'en': 'Chrome'})
@@ -523,27 +520,27 @@ class TestViewFeatureViewSet(APITestCase):
             Version, browser=browser_operamini_11, status="current")
 
         support_chrome_358 = self.create(
-            Support, version=version_chrome_758, feature=feature_row_191)
+            Support, version=version_chrome_758, feature=feature_816)
         support_firefox_359 = self.create(
-            Support, version=version_firefox_759, feature=feature_row_191)
+            Support, version=version_firefox_759, feature=feature_816)
         support_ie_360 = self.create(
-            Support, version=version_ie_760, feature=feature_row_191)
+            Support, version=version_ie_760, feature=feature_816)
         support_opera_361 = self.create(
-            Support, version=version_opera_761, feature=feature_row_191)
+            Support, version=version_opera_761, feature=feature_816)
         support_safari_362 = self.create(
-            Support, version=version_safari_762, feature=feature_row_191)
+            Support, version=version_safari_762, feature=feature_816)
         support_android_363 = self.create(
-            Support, version=version_android_763, feature=feature_row_191)
+            Support, version=version_android_763, feature=feature_816)
         support_ffmobile_364 = self.create(
-            Support, version=version_ffmobile_764, feature=feature_row_191)
+            Support, version=version_ffmobile_764, feature=feature_816)
         support_iephone_365 = self.create(
-            Support, version=version_iephone_765, feature=feature_row_191)
+            Support, version=version_iephone_765, feature=feature_816)
         support_operamobile_366 = self.create(
-            Support, version=version_operamobile_766, feature=feature_row_191)
+            Support, version=version_operamobile_766, feature=feature_816)
         support_safarimobile_367 = self.create(
-            Support, version=version_safarimobile_767, feature=feature_row_191)
+            Support, version=version_safarimobile_767, feature=feature_816)
         support_operamini_368 = self.create(
-            Support, version=version_operamini_768, feature=feature_row_191)
+            Support, version=version_operamini_768, feature=feature_816)
 
         mat_23 = self.create(
             Maturity, slug='Living', name={'en': 'Living Standard'})
@@ -620,9 +617,21 @@ class TestViewFeatureViewSet(APITestCase):
                         str(section_421.pk),
                         str(section_70.pk),
                     ],
-                    "supports": [],
+                    "supports": [
+                        str(support_chrome_358.pk),
+                        str(support_firefox_359.pk),
+                        str(support_ie_360.pk),
+                        str(support_opera_361.pk),
+                        str(support_safari_362.pk),
+                        str(support_android_363.pk),
+                        str(support_ffmobile_364.pk),
+                        str(support_iephone_365.pk),
+                        str(support_operamobile_366.pk),
+                        str(support_safarimobile_367.pk),
+                        str(support_operamini_368.pk)
+                    ],
                     "parent": str(feature_parent_800.id),
-                    "children": [str(feature_row_191.id)],
+                    "children": [],
                     "history_current": self.history_pk_str(feature_816),
                     "history": self.history_pks_str(feature_816),
                 }
@@ -783,41 +792,7 @@ class TestViewFeatureViewSet(APITestCase):
                         }
                     }
                 ],
-                "features": [
-                    {
-                        "id": str(feature_row_191.id),
-                        "slug": "html-address",
-                        "experimental": False,
-                        "standardized": True,
-                        "stable": True,
-                        "obsolete": False,
-                        "name": {
-                            "en": "Basic support"
-                        },
-                        "mdn_uri": None,
-                        "links": {
-                            "sections": [],
-                            "supports": [
-                                str(support_chrome_358.pk),
-                                str(support_firefox_359.pk),
-                                str(support_ie_360.pk),
-                                str(support_opera_361.pk),
-                                str(support_safari_362.pk),
-                                str(support_android_363.pk),
-                                str(support_ffmobile_364.pk),
-                                str(support_iephone_365.pk),
-                                str(support_operamobile_366.pk),
-                                str(support_safarimobile_367.pk),
-                                str(support_operamini_368.pk)
-                            ],
-                            "parent": str(feature_816.id),
-                            "children": [],
-                            "history_current": self.history_pk_str(
-                                feature_row_191),
-                            "history": self.history_pks_str(feature_row_191),
-                        }
-                    }
-                ],
+                "features": [],
                 "maturities": [
                     {
                         "id": str(mat_23.id),
@@ -959,7 +934,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_chrome_758.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_chrome_358),
                             "history": self.history_pks_str(
@@ -979,7 +954,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_firefox_759.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_firefox_359),
                             "history": self.history_pks_str(
@@ -999,7 +974,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_ie_760.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_ie_360),
                             "history": self.history_pks_str(
@@ -1019,7 +994,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_opera_761.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_opera_361),
                             "history": self.history_pks_str(
@@ -1039,7 +1014,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_safari_762.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_safari_362),
                             "history": self.history_pks_str(
@@ -1059,7 +1034,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_android_763.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_android_363),
                             "history": self.history_pks_str(
@@ -1079,7 +1054,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_ffmobile_764.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_ffmobile_364),
                             "history": self.history_pks_str(
@@ -1099,7 +1074,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_iephone_765.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_iephone_365),
                             "history": self.history_pks_str(
@@ -1119,7 +1094,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_operamobile_766.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_operamobile_366),
                             "history": self.history_pks_str(
@@ -1139,7 +1114,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_safarimobile_767.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_safarimobile_367),
                             "history": self.history_pks_str(
@@ -1159,7 +1134,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "note": None,
                         "links": {
                             "version": str(version_operamini_768.id),
-                            "feature": str(feature_row_191.id),
+                            "feature": str(feature_816.id),
                             "history_current": self.history_pk_str(
                                 support_operamini_368),
                             "history": self.history_pks_str(
@@ -1527,8 +1502,7 @@ class TestViewFeatureViewSet(APITestCase):
                         }
                     ],
                     "supports": {
-                        str(feature_816.pk): {},
-                        str(feature_row_191.pk): {
+                        str(feature_816.pk): {
                             str(browser_chrome_1.pk): [
                                 str(support_chrome_358.pk)],
                             str(browser_firefox_2.pk): [
@@ -1557,7 +1531,7 @@ class TestViewFeatureViewSet(APITestCase):
                         "linked.features": {
                             "previous": None,
                             "next": None,
-                            "count": 1,
+                            "count": 0,
                         },
                     },
                     "languages": ['en', 'ja', 'jp'],


### PR DESCRIPTION
Previously, "Basic support" rows were imported as child rows of the feature.  This PR changes these to describing the feature itself.

"Basic support" was used to test importing of child rows.  This is switched to a new test row, ``<code>contain</code> and <code>cover</code>``, another row on [Web/CSS/background-size](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size#Browser_compatibility).  The difference in text size means many issue spans changed.

The display code was updated to add a "Basic support" row with the supports for the subject feature.  Some same localizations are also provided.