### PR TITLE
Handle changed whitespace in Spec2

### DIFF
--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -115,7 +115,7 @@ class LoadSpecData(Tool):
         phase = 0
         key = None
         name = None
-        status_re = re.compile(r"\s+['\"](.*)['\"]\s+: ['\"](.*)['\"],?\s*$")
+        status_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
         mat_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*mdn\.localString\({\s*$")
         name_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
         local_specs = collection.get_resources_by_data_id('specifications')


### PR DESCRIPTION
This line in [Spec2](https://developer.mozilla.org/en-US/docs/Template:Spec2) was breaking tools/load_spec_data.py:

```
  'Unhandled Promise Rejection': 'ED',
```

Adjust the regex to handle optional space in these lines.