### PR TITLE
bug 1128525 - Adjust browser names and slugs

### DIFF
--- a/mdn/compatibility.py
+++ b/mdn/compatibility.py
@@ -219,21 +219,10 @@ class CompatSectionExtractor(Extractor):
             self.add_issue('feature_header', element, header=header)
         self.columns.append(header)
 
-    browser_name_fixes = {
-        'Firefox (Gecko)': 'Firefox',
-        'Firefox Mobile (Gecko)': 'Firefox Mobile',
-        'Firefox OS (Gecko)': 'Firefox OS',
-        'Safari (WebKit)': 'Safari',
-        'Windows Phone': 'IE Mobile',
-        'IE Phone': 'IE Mobile',
-        'IE': 'Internet Explorer',
-    }
-
     def extract_browser_name(self, element):
         colspan = int(element.attributes.get('colspan', 1))
         raw_name = element.to_text()
-        fixed_name = self.browser_name_fixes.get(raw_name, raw_name)
-        browser_params = self.data.lookup_browser_params(fixed_name)
+        browser_params = self.data.lookup_browser_params(raw_name)
         browser, browser_id, name, slug = browser_params
         if not browser:
             self.add_issue('unknown_browser', element, name=raw_name)

--- a/mdn/data.py
+++ b/mdn/data.py
@@ -24,6 +24,16 @@ class Data(object):
     BrowserParams = namedtuple(
         'BrowserParams', ['browser', 'browser_id', 'name', 'slug'])
 
+    browser_name_fixes = {
+        'Firefox (Gecko)': 'Firefox',
+        'Firefox Mobile (Gecko)': 'Firefox Mobile',
+        'Firefox OS (Gecko)': 'Firefox OS',
+        'Safari (WebKit)': 'Safari',
+        'Windows Phone': 'IE Mobile',
+        'IE Phone': 'IE Mobile',
+        'IE': 'Internet Explorer',
+    }
+
     def lookup_browser_params(self, name, locale='en'):
         """Get or create the browser ID, name, and slug given a raw name.
 
@@ -41,13 +51,16 @@ class Data(object):
                 self.browser_data[key] = self.BrowserParams(
                     browser, browser.pk, key, browser.slug)
 
+        # Handle common alternate names
+        fixed_name = self.browser_name_fixes.get(name, name)
+
         # Select the Browser ID and slug
-        if name not in self.browser_data:
-            browser_id = '_' + name
+        if fixed_name not in self.browser_data:
+            browser_id = '_' + fixed_name
             # TODO: unique slugify instead of browser_id
-            self.browser_data[name] = self.BrowserParams(
-                None, browser_id, name, browser_id)
-        return self.browser_data[name]
+            self.browser_data[fixed_name] = self.BrowserParams(
+                None, browser_id, fixed_name, browser_id)
+        return self.browser_data[fixed_name]
 
     FeatureParams = namedtuple(
         'FeatureParams', ['feature', 'feature_id', 'slug'])

--- a/mdn/tests/base.py
+++ b/mdn/tests/base.py
@@ -58,11 +58,13 @@ class TestCase(BaseTestCase):
         ('Feature', 'web-css-background-size-contain_and_cover'): {
             '_req': {'parent': ('Feature', 'web-css-background-size')},
             'name': '{"en": "<code>contain</code> and <code>cover</code>"}'},
-        ('Browser', 'chrome'): {'name': '{"en": "Chrome"}'},
-        ('Browser', 'firefox'): {'name': '{"en": "Firefox"}'},
-        ('Version', ('chrome', '1.0')): {},
-        ('Version', ('firefox', 'current')): {},
-        ('Version', ('firefox', '1.0')): {},
+        ('Browser', 'chrome_desktop'): {
+            'name': '{"en": "Chrome for Desktop"}'},
+        ('Browser', 'firefox_desktop'): {
+            'name': '{"en": "Firefox for Desktop"}'},
+        ('Version', ('chrome_desktop', '1.0')): {},
+        ('Version', ('firefox_desktop', 'current')): {},
+        ('Version', ('firefox_desktop', '1.0')): {},
     }
 
     def get_instance(self, model_cls_name, slug):

--- a/mdn/tests/test_compatibility.py
+++ b/mdn/tests/test_compatibility.py
@@ -17,7 +17,7 @@ class TestCompatSectionExtractor(TestCase):
     def setUp(self):
         self.feature = self.get_instance('Feature', 'web-css-background-size')
         self.visitor = KumaVisitor()
-        self.version = self.get_instance('Version', ('firefox', '1.0'))
+        self.version = self.get_instance('Version', ('firefox_desktop', '1.0'))
 
     def construct_html(
             self, header=None, pre_table=None, feature=None,
@@ -56,7 +56,8 @@ class TestCompatSectionExtractor(TestCase):
         return {
             'name': u'desktop',
             'browsers': [{
-                'id': browser_id, 'name': 'Firefox', 'slug': 'firefox'}],
+                'id': browser_id, 'name': 'Firefox for Desktop',
+                'slug': 'firefox_desktop'}],
             'versions': [{
                 'browser': browser_id, 'id': version_id, 'version': '1.0'}],
             'features': [{
@@ -160,9 +161,9 @@ class TestCompatSectionExtractor(TestCase):
         expected_mobile = {
             'name': 'mobile',
             'browsers': [{
-                'id': '_Safari Mobile',
-                'name': 'Safari Mobile',
-                'slug': '_Safari Mobile',
+                'id': '_Safari for iOS',
+                'name': 'Safari for iOS',
+                'slug': '_Safari for iOS',
             }],
             'features': [{
                 'id': '_contain and cover',
@@ -170,15 +171,15 @@ class TestCompatSectionExtractor(TestCase):
                 'slug': 'web-css-background-size_contain_and_cover',
             }],
             'versions': [{
-                'id': '_Safari Mobile-1.0',
+                'id': '_Safari for iOS-1.0',
                 'version': '1.0',
-                'browser': '_Safari Mobile',
+                'browser': '_Safari for iOS',
             }],
             'supports': [{
-                'id': '__contain and cover-_Safari Mobile-1.0',
+                'id': '__contain and cover-_Safari for iOS-1.0',
                 'feature': '_contain and cover',
                 'support': 'yes',
-                'version': '_Safari Mobile-1.0',
+                'version': '_Safari for iOS-1.0',
                 'footnote': "It's really supported.",
                 'footnote_id': ('1', 581, 584),
             }],
@@ -602,24 +603,25 @@ class TestSupportVisitor(TestCase):
         self.assert_support('1.0', [{'version': '1.0'}], [{'support': 'yes'}])
 
     def test_version_matches(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         self.set_browser(version.browser)
         self.assert_support(
             '1.0', [{'version': '1.0', 'id': version.id}],
             [{'support': 'yes'}])
 
     def test_new_version_existing_browser(self):
-        browser = self.get_instance('Browser', 'firefox')
+        browser = self.get_instance('Browser', 'firefox_desktop')
         self.set_browser(browser)
         issue = (
             'unknown_version', 4, 7,
-            {'browser_id': browser.id, 'browser_name': {"en": "Firefox"},
-             'browser_slug': 'firefox', 'version': '2.0'})
+            {'browser_id': browser.id,
+             'browser_name': {"en": "Firefox for Desktop"},
+             'browser_slug': 'firefox_desktop', 'version': '2.0'})
         self.assert_support(
             '2.0', [{'version': '2.0'}], [{'support': 'yes'}], issues=[issue])
 
     def test_support_matches(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         self.set_browser(version.browser)
         feature = self.get_instance(
             'Feature', 'web-css-background-size-contain_and_cover')

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -61,13 +61,14 @@ class BaseTestCase(TestCase):
  </table>
 </div>
 """
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         browser_id = version.browser_id
         version_id = version.id
         expected_compat = [{
             'name': u'desktop',
             'browsers': [{
-                'id': browser_id, 'name': 'Firefox', 'slug': 'firefox'}],
+                'id': browser_id, 'name': 'Firefox for Desktop',
+                'slug': 'firefox_desktop'}],
             'versions': [{
                 'browser': browser_id, 'id': version_id, 'version': '1.0'}],
             'features': [{
@@ -395,12 +396,12 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         self.assertDataEqual(expected, section_content)
 
     def test_load_browser(self):
-        browser = self.get_instance('Browser', 'firefox')
+        browser = self.get_instance('Browser', 'firefox_desktop')
         view = ScrapedViewFeature(self.page, self.empty_scrape())
         browser_content = view.load_browser(browser.id)
         expected = {
-            'id': str(browser.id), 'name': {'en': 'Firefox'}, 'note': None,
-            'slug': browser.slug}
+            'id': str(browser.id), 'name': {'en': 'Firefox for Desktop'},
+            'note': None, 'slug': browser.slug}
         self.assertDataEqual(expected, browser_content)
 
     def test_new_browser(self):
@@ -415,7 +416,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         self.assertDataEqual(expected, browser_content)
 
     def test_load_version(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         view = ScrapedViewFeature(self.page, self.empty_scrape())
         version_content = view.load_version(version.id)
         expected = {
@@ -526,7 +527,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         self.assertDataEqual(expected, feature_content)
 
     def test_load_support(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         feature = self.get_instance(
             'Feature', 'web-css-background-size-contain_and_cover')
         support = self.create(Support, version=version, feature=feature)
@@ -652,7 +653,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         self.assertDataEqual(expected, out)
 
     def test_load_compat_table_existing_resources(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         browser = version.browser
         feature = self.get_instance(
             'Feature', 'web-css-background-size-contain_and_cover')
@@ -691,7 +692,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         self.assertDataEqual(expected, out)
 
     def test_load_compat_table_basic_support(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         browser = version.browser
         feature = self.feature
         browser_id = str(browser.id)
@@ -728,7 +729,7 @@ class TestScrapedViewFeature(FeaturePageTestCase):
         self.assertDataEqual(expected, out)
 
     def test_load_compat_table_new_support_with_note(self):
-        version = self.get_instance('Version', ('firefox', '1.0'))
+        version = self.get_instance('Version', ('firefox_desktop', '1.0'))
         browser = version.browser
         feature = self.get_instance(
             'Feature', 'web-css-background-size-contain_and_cover')


### PR DESCRIPTION
The current browser names and slugs suggest that the desktop variants are the normal ones, and the mobile ones are the different ones.  [bug 1128525](https://bugzilla.mozilla.org/show_bug.cgi?id=1128525) changes this, so that "Firefox" (slug "firefox") becomes "Firefox for Desktop" (slug "firefox_desktop").  This is a three-part change:

1. This PR, which makes the importer handle current and new names and slugs
2. Once shipped, change the names and slugs in https://browsercompat.herokuapp.com
3. Remove the old name and slug handling from the importer.