### PR TITLE
Fix categorization of browsers for new slugs

### DIFF
--- a/docs/raw/view-feature-by-id-response-body.json
+++ b/docs/raw/view-feature-by-id-response-body.json
@@ -919,26 +919,26 @@
             "tabs": [
                 {
                     "name": {
-                        "en": "Desktop Browsers"
-                    },
-                    "browsers": [
-                        "3",
-                        "6",
-                        "10",
-                        "11",
-                        "14"
-                    ]
-                },
-                {
-                    "name": {
                         "en": "Mobile Browsers"
                     },
                     "browsers": [
                         "1",
+                        "2",
+                        "9"
+                    ]
+                },
+                {
+                    "name": {
+                        "en": "Non-Browser Environments"
+                    },
+                    "browsers": [
+                        "3",
+                        "6",
                         "7",
-                        "9",
-                        "15",
-                        "2"
+                        "10",
+                        "11",
+                        "14",
+                        "15"
                     ]
                 }
             ],

--- a/docs/raw/view-feature-by-id-with-child-pages-response-body.json
+++ b/docs/raw/view-feature-by-id-with-child-pages-response-body.json
@@ -919,26 +919,26 @@
             "tabs": [
                 {
                     "name": {
-                        "en": "Desktop Browsers"
-                    },
-                    "browsers": [
-                        "3",
-                        "6",
-                        "10",
-                        "11",
-                        "14"
-                    ]
-                },
-                {
-                    "name": {
                         "en": "Mobile Browsers"
                     },
                     "browsers": [
                         "1",
+                        "2",
+                        "9"
+                    ]
+                },
+                {
+                    "name": {
+                        "en": "Non-Browser Environments"
+                    },
+                    "browsers": [
+                        "3",
+                        "6",
                         "7",
-                        "9",
-                        "15",
-                        "2"
+                        "10",
+                        "11",
+                        "14",
+                        "15"
                     ]
                 }
             ],

--- a/docs/raw/view-feature-update-parts-with-changeset-5-response-body.json
+++ b/docs/raw/view-feature-update-parts-with-changeset-5-response-body.json
@@ -919,26 +919,26 @@
             "tabs": [
                 {
                     "name": {
-                        "en": "Desktop Browsers"
-                    },
-                    "browsers": [
-                        "3",
-                        "6",
-                        "10",
-                        "11",
-                        "14"
-                    ]
-                },
-                {
-                    "name": {
                         "en": "Mobile Browsers"
                     },
                     "browsers": [
                         "1",
+                        "2",
+                        "9"
+                    ]
+                },
+                {
+                    "name": {
+                        "en": "Non-Browser Environments"
+                    },
+                    "browsers": [
+                        "3",
+                        "6",
                         "7",
-                        "9",
-                        "15",
-                        "2"
+                        "10",
+                        "11",
+                        "14",
+                        "15"
                     ]
                 }
             ],

--- a/mdn/data.py
+++ b/mdn/data.py
@@ -24,17 +24,7 @@ class Data(object):
     BrowserParams = namedtuple(
         'BrowserParams', ['browser', 'browser_id', 'name', 'slug'])
 
-    # bug 1128525 changes names and slugs so that desktop isn't implied
-    pre_1128525_name_fixes = {
-        'Firefox (Gecko)': 'Firefox',
-        'Firefox Mobile (Gecko)': 'Firefox Mobile',
-        'Firefox OS (Gecko)': 'Firefox OS',
-        'Safari (WebKit)': 'Safari',
-        'Windows Phone': 'IE Mobile',
-        'IE Phone': 'IE Mobile',
-        'IE': 'Internet Explorer',
-    }
-    post_1128525_name_fixes = {
+    browser_name_fixes = {
         'Android': 'Android Browser',
         'BlackBerry': 'BlackBerry Browser',
         'Chrome': 'Chrome for Desktop',
@@ -66,19 +56,12 @@ class Data(object):
         * slug - A unique slug for this browser
         """
         # Load existing browser data
-        # Also, detect if names and slugs have been changed by bug 1128525
         if self.browser_data is None:
             self.browser_data = {}
             for browser in Browser.objects.all():
                 key = browser.name[locale]
-                if key == 'Firefox':
-                    self.browser_name_fixes = self.pre_1128525_name_fixes
-                if key == 'Firefox for Desktop':
-                    self.browser_name_fixes = self.post_1128525_name_fixes
                 self.browser_data[key] = self.BrowserParams(
                     browser, browser.pk, key, browser.slug)
-            if not hasattr(self, 'browser_name_fixes'):
-                self.browser_name_fixes = self.pre_1128525_name_fixes
 
         # Expand to full name, handle common alternate names
         full_name = self.browser_name_fixes.get(name, name)

--- a/mdn/tests/test_data.py
+++ b/mdn/tests/test_data.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from mdn.data import Data
-from webplatformcompat.models import Browser, Feature, Support
+from webplatformcompat.models import Feature, Support
 from .base import TestCase
 
 
@@ -23,19 +23,7 @@ class TestLookupBrowserParams(TestDataBase):
             new_params = self.data.lookup_browser_params(raw_name)
         self.assertEqual(params, new_params)
 
-    def test_browser_params_new_pre_1128525(self):
-        self.create(Browser, slug="chrome", name='{"en": "Chrome"}')
-        self.create(Browser, slug="firefox", name='{"en": "Firefox"}')
-        self.assert_browser_params(
-            'Safari', None, '_Safari', 'Safari', '_Safari')
-
-    def test_browser_params_new_defaults_to_pre_1128525(self):
-        self.assert_browser_params(
-            'Safari', None, '_Safari', 'Safari', '_Safari')
-
-    def test_browser_params_new_post_1128525(self):
-        self.get_instance('Browser', 'chrome_desktop')
-        self.get_instance('Browser', 'firefox_desktop')
+    def test_browser_params_new_browser(self):
         self.assert_browser_params(
             'Safari', None, '_Safari for Desktop', 'Safari for Desktop',
             '_Safari for Desktop')

--- a/webplatformcompat/tests/test_view_serializers.py
+++ b/webplatformcompat/tests/test_view_serializers.py
@@ -34,7 +34,8 @@ class TestViewFeatureViewSet(APITestCase):
 
     def setup_minimal(self):
         feature = self.create(Feature, slug='feature')
-        browser = self.create(Browser, slug='chrome', name={'en': 'Browser'})
+        browser = self.create(
+            Browser, slug='chrome_desktop', name={'en': 'Browser'})
         version = self.create(Version, browser=browser, status='current')
         support = self.create(Support, version=version, feature=feature)
         maturity = self.create(
@@ -92,7 +93,7 @@ class TestViewFeatureViewSet(APITestCase):
             "linked": {
                 "browsers": [{
                     "id": str(browser.pk),
-                    "slug": "chrome",
+                    "slug": "chrome_desktop",
                     "name": {"en": "Browser"},
                     "note": None,
                     "links": {

--- a/webplatformcompat/view_serializers.py
+++ b/webplatformcompat/view_serializers.py
@@ -603,21 +603,22 @@ class ViewFeatureExtraSerializer(ModelSerializer):
         TODO: Move this logic into the database, API
         """
         known_browsers = dict((
-            ('chrome', ('Desktop Browsers', 1)),
-            ('firefox', ('Desktop Browsers', 2)),
-            ('internet_explorer', ('Desktop Browsers', 3)),
-            ('opera', ('Desktop Browsers', 4)),
-            ('safari', ('Desktop Browsers', 5)),
-            ('android', ('Mobile Browsers', 6)),
-            ('chrome_for_android', ('Mobile Browsers', 7)),
-            ('chrome_mobile', ('Mobile Browsers', 8)),
-            ('firefox_mobile', ('Mobile Browsers', 9)),
-            ('ie_mobile', ('Mobile Browsers', 10)),
-            ('opera_mini', ('Mobile Browsers', 11)),
-            ('opera_mobile', ('Mobile Browsers', 12)),
-            ('safari_mobile', ('Mobile Browsers', 13)),
-            ('blackberry', ('Mobile Browsers', 14)),
-            ('firefox_os', ('Non-Browser Environments', 15)),
+            ('chrome_desktop', ('Desktop Browsers', 1)),
+            ('edge', ('Desktop Browsers', 2)),
+            ('firefox_desktop', ('Desktop Browsers', 3)),
+            ('ie_desktop', ('Desktop Browsers', 4)),
+            ('opera_desktop', ('Desktop Browsers', 5)),
+            ('safari_desktop', ('Desktop Browsers', 6)),
+            ('android', ('Mobile Browsers', 10)),
+            ('android_webview', ('Mobile Browsers', 11)),
+            ('blackberry', ('Mobile Browsers', 12)),
+            ('chrome_for_android', ('Mobile Browsers', 13)),
+            ('firefox_android', ('Mobile Browsers', 14)),
+            ('ie_mobile', ('Mobile Browsers', 15)),
+            ('opera_mini', ('Mobile Browsers', 16)),
+            ('opera_mobile', ('Mobile Browsers', 17)),
+            ('safari_ios', ('Mobile Browsers', 18)),
+            ('firefox_os', ('Non-Browser Environments', 20)),
         ))
         next_other = 16
         sections = [


### PR DESCRIPTION
The ``view_feature`` response includes a suggested categorization and ordering of browsers, hard-coded by slugs.  Because the new slugs went live in production, browsers with new slugs are mostly categorized as "Non-Browser Environments".  This categorization is used in the table display logic, which is now showing weird results.

This PR updates the categorization for the new slugs, adds support for Edge, and alpha-sorts within a category.  It also drops code to handle the transition to the new slugs.

The integration tests have been minimally updated so they will pass.  Updating the slugs in the integration tests is a much larger effort.  This PR will fix the front-end code, so that work can continue there.  A future PR will change the integration tests to use the new slugs, so the documentation will better reflect production data.