### PR TITLE
bug 1153288 - Pin flake8 dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,11 @@ deps = {[base]deps}
 [testenv:flake8]
 deps =
     {[base]deps}
+    mccabe==0.3.1
+    pep8==1.5.7
+    pyflakes==1.0.0
     flake8==2.4.1
+    pep257==0.6.0
     flake8-docstrings==0.2.1.post1
 commands = flake8
 


### PR DESCRIPTION
Pin versions of packages installed by flake8. Currently, the TravisCI flake8 build is broken because pep257 updated to 0.7.0, and is finding more documentation issues with the code.