### PR TITLE
bug 1181140 - Hide reparse button in production

### DIFF
--- a/mdn/helpers.py
+++ b/mdn/helpers.py
@@ -2,6 +2,7 @@
 
 This file is loaded by jingo and must be named helpers.py
 """
+from django.conf import settings
 from django.utils.six.moves.urllib_parse import urlencode
 from jinja2 import contextfunction, Markup
 
@@ -155,7 +156,7 @@ def can_refresh_mdn_import(context, user):
 
 @contextfunction
 def can_reparse_mdn_import(context, user):
-    return can_create(user)
+    return settings.MDN_SHOW_REPARSE and can_create(user)
 
 
 @contextfunction

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -44,6 +44,7 @@ FXA_OAUTH_ENDPOINT - Override for Firefox Account OAuth2 endpoint
 FXA_PROFILE_ENDPOINT - Override for Firefox Account profile endpoint
 MDN_ALLOWED_URL_PREFIXES - comma-separated list of URL prefixes allowed by
   the scraper
+MDN_SHOW_REPARSE - 1 to show Reparse button, defaults to DEBUG
 MEMCACHE_SERVERS - semicolon-separated list of memcache servers
 MEMCACHE_USERNAME - username for memcache servers
 MEMCACHE_PASSWORD - password for memcache servers
@@ -67,6 +68,14 @@ BASE_DIR = path.dirname(path.dirname(__file__))
 
 def rel_path(*subpaths):
     return path.join(BASE_DIR, *subpaths)
+
+
+def env_to_bool(environ_key, default):
+    """Convert an environment string to a bool."""
+    if environ_key in environ:
+        return environ[environ_key] in (1, '1')
+    else:
+        return default
 
 
 # Detect that we're running tests
@@ -279,6 +288,8 @@ if environ.get('MDN_ALLOWED_URL_PREFIXES') and not TESTING:
     MDN_ALLOWED_URLS = tuple(raw.split(','))
 else:
     MDN_ALLOWED_URLS = ('https://developer.mozilla.org/en-US/', )
+
+MDN_SHOW_REPARSE = env_to_bool('MDN_SHOW_REPARSE', DEBUG)
 
 #
 # 3rd Party Libraries


### PR DESCRIPTION
The reparse button is useful when developing locally, to test changes in the parsing code.  In production, the right thing is almost always to reset the page to download the latest from MDN.

This commit shows the button when ``DEBUG=True`` and hides it when ``False``, unless overridden by environment variable ``MDN_SHOW_REPARSE``.

``Original commit was based on request hostname being localhost or 127.0.0.1.``