### PR TITLE
fix bug 1188503 - Handle "current" version status

### DIFF
--- a/webplatformcompat/jinja2/webplatformcompat/feature-basic.html
+++ b/webplatformcompat/jinja2/webplatformcompat/feature-basic.html
@@ -93,20 +93,20 @@
           {%- set version_id = support['links']['version'] %}
           {%- set version = collection['versions'][version_id] %}
           {%- if not loop.first %}<br>{% endif %}
-          {%- if version.version %}
-          {%- if version.release_notes_uri %}
+            {%- if version.version %}
+              {%- if version.release_notes_uri %}
 
         <a href="{{trans_str(version.release_notes_uri)}}" title="Release Notes">{{version.version}}</a>
-          {%- else %}
+              {%- else %}
 
         {{version.version}}
-          {%- endif %}
+              {%- endif %}
 
-          {%- if support.support != 'yes'%} ({{support.support}}){% endif %}
-          {%- else %}
+              {%- if support.support != 'yes'%} ({{support.support}}){% endif %}
+            {%- else %}
 
         ({{ support.support }})
-          {%- endif %}
+            {%- endif %}
           {%- if support.prefix and support.prefix_mandatory %}
 
         <code>{{support.prefix}}</code>

--- a/webplatformcompat/jinja2/webplatformcompat/feature-basic.html
+++ b/webplatformcompat/jinja2/webplatformcompat/feature-basic.html
@@ -93,7 +93,7 @@
           {%- set version_id = support['links']['version'] %}
           {%- set version = collection['versions'][version_id] %}
           {%- if not loop.first %}<br>{% endif %}
-            {%- if version.version %}
+            {%- if version.version != 'current' %}
               {%- if version.release_notes_uri %}
 
         <a href="{{trans_str(version.release_notes_uri)}}" title="Release Notes">{{version.version}}</a>
@@ -119,7 +119,7 @@
           {%- endif %}
         {%- else %}
 
-        ?
+        ({{ support.support}})
         {%- endfor %}
 
       </td>

--- a/webplatformcompat/static/js/webplatformcompat.js
+++ b/webplatformcompat/static/js/webplatformcompat.js
@@ -284,7 +284,7 @@ window.WPC = {
                                     if (supportIdx !== 0) {
                                         td.appendChild(document.createElement('br'));
                                     }
-                                    if (version.version) {
+                                    if (version.version !== 'current') {
                                         releaseUri = this.trans_str(version.release_notes_uri, lang);
                                         if (releaseUri) {
                                             versionLink = document.createElement('a');
@@ -297,14 +297,14 @@ window.WPC = {
                                         }
                                     }
                                     if (support.support === 'no') {
-                                        if (version.version) {
+                                        if (version.version !== 'current') {
                                             td.appendChild(document.createTextNode(' '));
                                         }
                                         nosupport = document.createElement('span');
                                         nosupport.setAttribute('style', 'color: #f00;');
                                         nosupport.appendChild(document.createTextNode('Not supported'));
                                         td.appendChild(nosupport);
-                                    } else if (support.support !== 'yes' || (!version.version)) {
+                                    } else if (support.support !== 'yes' || (version.version === 'current')) {
                                         td.appendChild(document.createTextNode(' (' + support.support + ')'));
                                     }
 


### PR DESCRIPTION
The string "current" is used to denote "this happened so long ago we're not sure when". Before bug 1160214, this was denoted with a blank version. This updates the display code to expect "current" instead of a blank version.

One page that uses version=current is transform-origin:

https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin
https://browsercompat.herokuapp.com/view_feature/847
https://browsercompat.herokuapp.com/api/v1/view_features/847.html