### PR TITLE
bug 1188498 - Add messages framework to jinja2

### DIFF
--- a/webplatformcompat/jinja2/webplatformcompat/base.html
+++ b/webplatformcompat/jinja2/webplatformcompat/base.html
@@ -70,6 +70,7 @@
         {%- endblock body_title_elem %}
         {% block quick_nav %}{% endblock %}
         {% block messages %}
+          {% set messages = get_messages(request) %}
           {% if messages %}
             {% for message in messages %}
             <div class="alert alert-{{message.tags}} alert-dismissible fade in" role="alert">

--- a/wpcsite/jinja2.py
+++ b/wpcsite/jinja2.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.messages import get_messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext, ungettext
 from jinja2 import Environment
@@ -27,6 +28,7 @@ def environment(**options):
         '_': ugettext,
         'gettext': ugettext,
         'ngettext': ungettext,
+        'get_messages': get_messages,
     })
     for app_env in (wp_env, bcauth_env, mdn_env):
         for group, to_add in app_env.items():


### PR DESCRIPTION
Add the messages framework helpers to the native Jinja2 backend in Django 1.8.