### PR TITLE
fix bug 1210436 - Handle 404s in view_feature HTML

### DIFF
--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from json import loads
 
-from django.template import loader
+from django.template import loader, Context
 from django.utils import encoding, translation
 
 from rest_framework.relations import ManyRelatedField
@@ -235,6 +235,12 @@ class JsonApiTemplateHTMLRenderer(TemplateHTMLRenderer):
             data, accepted_media_type, renderer_context)
         context = loads(
             json_api.decode('utf-8'), object_pairs_hook=OrderedDict)
+
+        # Is it an error?
+        if 'errors' in context:
+            error_context = Context(context)
+            return super(JsonApiTemplateHTMLRenderer, self).render(
+                error_context, accepted_media_type, renderer_context)
 
         # Copy main item to generic 'data' key
         other_keys = ('linked', 'links', 'meta')

--- a/webplatformcompat/tests/test_view_serializers.py
+++ b/webplatformcompat/tests/test_view_serializers.py
@@ -529,6 +529,13 @@ class TestViewFeatureViewSet(APITestCase):
         response = self.client.get(url)
         self.assertEqual(404, response.status_code)
 
+    def test_feature_not_found_html(self):
+        self.assertFalse(Feature.objects.filter(id=666).exists())
+        url = reverse('viewfeatures-detail', kwargs={'pk': '666'}) + '.html'
+        response = self.client.get(url)
+        self.assertEqual(404, response.status_code)
+        self.assertEqual('404 Not Found', response.content.decode('utf8'))
+
 
 class TestViewFeatureUpdates(APITestCase):
     """Test PUT to a ViewFeature detail"""


### PR DESCRIPTION
In the rendered used by view_features, detect 404s and other errors and return the standard Django error page, instead of continuing to parse data and eventually failing with a 500 error.