### PR TITLE
bug 1153288 - More API fixes

### DIFF
--- a/docs/raw/maturity-by-slug-response-body.json
+++ b/docs/raw/maturity-by-slug-response-body.json
@@ -12,7 +12,8 @@
             "links": {
                 "specifications": [
                     "3",
-                    "4"
+                    "4",
+                    "5"
                 ],
                 "history_current": "2",
                 "history": [

--- a/docs/raw/specification-revert-response-body.json
+++ b/docs/raw/specification-revert-response-body.json
@@ -10,7 +10,7 @@
             "en": "http://dev.w3.org/csswg/css-ruby/"
         },
         "links": {
-            "maturity": "5",
+            "maturity": "2",
             "sections": [],
             "history_current": "7",
             "history": [

--- a/docs/raw/view-features-list-response-body.json
+++ b/docs/raw/view-features-list-response-body.json
@@ -37,7 +37,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "flex-shrink"
         },
         {
             "href": "https://browsercompat.org/api/v1/view_features/4",
@@ -50,7 +50,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "flex-wrap"
         },
         {
             "href": "https://browsercompat.org/api/v1/view_features/5",
@@ -67,7 +67,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "float"
         },
         {
             "href": "https://browsercompat.org/api/v1/view_features/6",
@@ -94,7 +94,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "font"
         },
         {
             "href": "https://browsercompat.org/api/v1/view_features/8",
@@ -107,7 +107,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "font-family"
         },
         {
             "href": "https://browsercompat.org/api/v1/view_features/9",
@@ -120,7 +120,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "font-feature-settings"
         },
         {
             "href": "https://browsercompat.org/api/v1/view_features/10",
@@ -136,7 +136,7 @@
             "standardized": true,
             "stable": true,
             "obsolete": false,
-            "name": null
+            "name": "transform-origin"
         }
     ],
     "meta": {

--- a/tools/integration_requests.py
+++ b/tools/integration_requests.py
@@ -168,9 +168,9 @@ class CaseRunner(object):
         out = self.format_response_for_display(response, case)
         header = "Test Case %d: %s" % (casenum, case['name'])
         print()
-        print(header)
+        print(header.encode('utf8'))
         print("*" * len(header))
-        print(out)
+        print(out.encode('utf8'))
         return []
 
     def generate(self, casenum, case, response):

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -111,7 +111,10 @@ class HistoricalModelSerializer(
                     for field in historical._meta.fields:
                         attname = field.attname
                         hist_value = getattr(historical, attname)
-                        data[attname] = hist_value
+                        data_name = attname
+                        if data_name.endswith('_id'):
+                            data_name = data_name[:-len('_id')]
+                        data[data_name] = hist_value
         return super(HistoricalModelSerializer, self).to_internal_value(data)
 
 

--- a/webplatformcompat/tests/test_serializers.py
+++ b/webplatformcompat/tests/test_serializers.py
@@ -207,6 +207,31 @@ class TestSpecificationSerializer(APITestCase):
         actual_sections = response.data['sections']
         self.assertEqual(expected_sections, actual_sections)
 
+    def test_set_and_revert_maturity(self):
+        old_maturity_id = self.spec.maturity.id
+        old_history_id = self.spec.history.all()[0].history_id
+        new_maturity = self.create(
+            Maturity, slug='FD', name={'en': 'Final Draft'})
+        data_set_maturity = {
+            'specifications': {
+                'links': {
+                    'maturity': str(new_maturity.id)
+                }
+            }
+        }
+        response = self.update_via_json_api(self.url, data_set_maturity)
+        self.assertEqual(response.data['maturity'], new_maturity.id)
+
+        data_revert = {
+            'specifications': {
+                'links': {
+                    'history_current': old_history_id
+                }
+            }
+        }
+        response = self.update_via_json_api(self.url, data_revert)
+        self.assertEqual(response.data['maturity'], old_maturity_id)
+
 
 class TestUserSerializer(APITestCase):
     """Test UserSerializer through the view."""

--- a/webplatformcompat/view_serializers.py
+++ b/webplatformcompat/view_serializers.py
@@ -19,7 +19,7 @@ from .cache import Cache
 from .models import (
     Browser, Feature, Maturity, Section, Specification, Support, Version)
 from .serializers import (
-    BrowserSerializer, FeatureSerializer, MaturitySerializer,
+    BrowserSerializer, FieldMapMixin, FeatureSerializer, MaturitySerializer,
     SectionSerializer, SpecificationSerializer, SupportSerializer,
     VersionSerializer, omit_some)
 
@@ -63,7 +63,7 @@ view_cls_by_name = {
 }
 
 
-class ViewFeatureListSerializer(ModelSerializer):
+class ViewFeatureListSerializer(FieldMapMixin, ModelSerializer):
     """Get list of features"""
     url = SerializerMethodField()
 


### PR DESCRIPTION
Fix some API issues discovered in Madison, WI:

* ``tools/integration_requests.py --display --include-mod`` fails due to unicode->ASCII encoding issues
* Reverting a specification did not set the maturity to the old value
* The ``view_features`` list view displayed canonical features names as ``none``.