### PR TITLE
fix bug 1224341 - Fix Feature.set_children_order

### DIFF
--- a/webplatformcompat/models.py
+++ b/webplatformcompat/models.py
@@ -120,6 +120,7 @@ class Feature(MPTTModel):
         for pos, next_child in enumerate(children):
             if current_children[pos].pk != next_child.pk:
                 if moved:
+                    prev_child.refresh_from_db()
                     next_child.refresh_from_db()
                 if prev_child is None:
                     next_child.move_to(self, "first-child")

--- a/webplatformcompat/tests/test_models.py
+++ b/webplatformcompat/tests/test_models.py
@@ -82,6 +82,13 @@ class TestFeature(TestCase):
         parent.set_children_order(new_order)
         self.assertEqual(list(parent.children.all()), new_order)
 
+    def test_set_children_swapped(self):
+        parent, children = self.add_family()
+        new_order = [
+            children[1], children[0], children[3], children[2], children[4]]
+        parent.set_children_order(new_order)
+        self.assertEqual(list(parent.children.all()), new_order)
+
 
 class TestMaturity(unittest.TestCase):
     def test_str(self):


### PR DESCRIPTION
In some cases (such as swapping each child pairs) it is necessary to reload both the previous and the next child from the database, so that the MPTT metadata is correct for the move.
