### PR TITLE
Namespace v1 API, to prepare for v2 API

### DIFF
--- a/bcauth/tests.py
+++ b/bcauth/tests.py
@@ -11,16 +11,22 @@ from .helpers import providers_media_js, provider_login_url
 
 
 class TestViews(TestCase):
+    def full_reverse(self, viewname):
+        """Create a full URL for a view."""
+        return 'http://testserver' + reverse(viewname)
+
     def test_account_anon(self):
         response = self.client.get(reverse('account_base'))
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response['Location'], self.reverse('account_login'))
+        self.assertEqual(
+            response['Location'], self.full_reverse('account_login'))
 
     def test_account_logged_in(self):
         self.login_user()
         response = self.client.get(reverse('account_base'))
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response['Location'], self.reverse('account_profile'))
+        self.assertEqual(
+            response['Location'], self.full_reverse('account_profile'))
 
     def test_profile_anon(self):
         url = reverse('account_profile')
@@ -28,7 +34,7 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response['Location'],
-            self.reverse('account_login') + '?next=' + url)
+            self.full_reverse('account_login') + '?next=' + url)
 
     def test_profile_logged_in(self):
         user = self.login_user()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,24 +13,24 @@ docutils==0.12
 py==1.4.30
 pluggy==0.3.1
 virtualenv==13.1.2
-tox==2.1.1
+tox==2.2.1
 
 # PEP8, PEP257 and static analysis
 mccabe==0.3.1
-pep8==1.5.7  # rq.filter: <1.6,>=1.5.7
+pep8==1.6.2
 pyflakes==1.0.0
-flake8==2.4.1
+flake8==2.5.0
 pep257==0.6.0
 flake8-docstrings==0.2.1.post1
 
 # MANIFEST.in checker
-check-manifest==0.25
+check-manifest==0.28
 
 # Package QA
-pyroma==1.8.2
+pyroma==1.8.3
 
 # For ./manage.py runserver_plus
-Werkzeug==0.10.4
+Werkzeug==0.11.2
 
 # Better shell, debugger
 gnureadline==6.3.3
@@ -38,11 +38,11 @@ ipython==4.0.0
 ipdb==0.8.1
 
 # Debugging
-sqlparse==0.1.16
-django-debug-toolbar==1.3.2
+sqlparse==0.1.18
+django-debug-toolbar==1.4
 
 # Test coverage
-coverage==4.0
+coverage==4.0.2
 docopt==0.6.2
 PyYAML==3.11
-coveralls==1.0
+coveralls==1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ mccabe==0.3.1
 pep8==1.6.2
 pyflakes==1.0.0
 flake8==2.5.0
-pep257==0.6.0
+pep257==0.7.0
 flake8-docstrings==0.2.1.post1
 
 # MANIFEST.in checker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for production / heroku
 
 # Django
-Django==1.8.5  # rq.filter: >=1.8, <1.9
+Django==1.8.6  # rq.filter: >=1.8, <1.9
 
 # Better templates
 MarkupSafe==0.23
@@ -9,12 +9,12 @@ Jinja2==2.8
 
 # Django REST Framework.
 djangorestframework==3.2.4
-Markdown==2.6.2
+Markdown==2.6.4
 django-filter==0.11.0
 
 # Django extensions
-six==1.9.0
-django-extensions==1.5.7
+six==1.10.0
+django-extensions==1.5.9
 
 # JSON API interfaces for Django REST Framework
 git+git://github.com/jwhitlock/drf-json-api@v0.1d#egg=drf-json-api
@@ -27,7 +27,7 @@ dj-database-url==0.3.0
 
 # Better test runner (included in settings)
 nose==1.3.7
-django-nose==1.4.1
+django-nose==1.4.2
 
 # Test Mocking, included in Python 3.3
 mock==1.3.0
@@ -43,7 +43,7 @@ static3==0.6.1
 dj-static==0.0.6
 
 # Timezone info
-pytz==2015.6
+pytz==2015.7
 
 # Fast Memcache connections, and tell Heroku to install C dependencies
 pylibmc==1.5.0
@@ -55,11 +55,11 @@ redis==2.10.5
 django-redis==4.3.0
 
 # Celery - async task management
-billiard==3.3.0.20
-amqp==1.4.6
+billiard==3.3.0.21
+amqp==1.4.7
 anyjson==0.3.3
-kombu==3.0.26
-celery==3.1.18
+kombu==3.0.29
+celery==3.1.19
 
 # Modified Preorder Tree Traversal
 django-mptt==0.7.4
@@ -83,12 +83,10 @@ git+git://github.com/erikrose/parsimonious@20863d86a#egg=parsimonious
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app
 # python3-openid >= 3.0.1 # Python 3.x - unused by app
-requests==2.7.0
+requests==2.8.1
 oauthlib==1.0.3
 requests-oauthlib==0.5.0
-# django-allauth==0.23.0
-# Can't use Jinja2 for some views - bug #1133, merged to master
-git+git://github.com/pennersr/django-allauth@6393b45#egg=django-allauth
+django-allauth==0.24.1
 
 # Unicode-aware CSVs
 unicodecsv==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ MarkupSafe==0.23
 Jinja2==2.8
 
 # Django REST Framework.
-djangorestframework==3.2.4
+djangorestframework==3.3.1
 Markdown==2.6.4
 django-filter==0.11.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,15 +31,17 @@ omit =
 
 [flake8]
 exclude = ./.tox/
-# PEP257 (docstring) warnings to ignore (for now)
-# D100 - Docstring missing in public module
-# D101 - Docstring missing in public class
-# D102 - Docstring missing in public method
-# D103 - Docstring missing in public function
-# D203 - Expected 1 blank line before class docstring
-# D204 - Expected 1 blank line after class docstring
-# D400 - First line should end with '.'
-ignore = D100,D101,D102,D103,D203,D204,D400
+# PEP257 (docstring) warnings to ignore (with counts as of Nov 2015)
+# D100 - Missing docstring in public module (41)
+# D101 - Missing docstring in public class (294)
+# D102 - Missing docstring in public method (1185)
+# D103 - Missing docstring in public function (38)
+# D104 - Missing docstring in public package (10)
+# D105 - Missing docstring in magic method (21)
+# D204 - 1 blank line required after class docstring (65)
+# D211 - No blank lines allowed before class docstring (3)
+# D400 - First line should end with a period (140)
+ignore = D100,D101,D102,D103,D104,D105,D204,D211,D400
 
 [wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     pep8==1.6.2
     pyflakes==1.0.0
     flake8==2.5.0
-    pep257==0.6.0
+    pep257==0.7.0
     flake8-docstrings==0.2.1.post1
 commands = flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,9 @@ deps = {[base]deps}
 deps =
     {[base]deps}
     mccabe==0.3.1
-    pep8==1.5.7
+    pep8==1.6.2
     pyflakes==1.0.0
-    flake8==2.4.1
+    flake8==2.5.0
     pep257==0.6.0
     flake8-docstrings==0.2.1.post1
 commands = flake8
@@ -35,8 +35,8 @@ commands = sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     {[base]deps}
-    coverage==4.0
-    coveralls==1.0
+    coverage==4.0.2
+    coveralls==1.1
 commands =
     coverage run --source bcauth,mdn,webplatformcompat,tools setup.py test
     coverage report -m

--- a/webplatformcompat/jinja2/webplatformcompat/base.html
+++ b/webplatformcompat/jinja2/webplatformcompat/base.html
@@ -42,7 +42,7 @@
             <li{% if request.path.startswith(url('about')) %} class="active"{% endif %}>
               <a href="{{url('about')}}">About</a></li>
             <li{% if request.path.startswith(url('api_root')) %} class="active"{% endif %}>
-              <a href="{{url('api-root')}}">API</a></li>
+              <a href="{{url('v1:api-root')}}">API</a></li>
             <li{% if request.path.startswith(url('browse')) %} class="active"{% endif %}>
               <a href="{{url('browse')}}">Browse</a></li>
             <li{% if request.path.startswith(url('feature_page_list')) %} class="active"{% endif %}>

--- a/webplatformcompat/jinja2/webplatformcompat/home.html
+++ b/webplatformcompat/jinja2/webplatformcompat/home.html
@@ -30,7 +30,7 @@
     <div class="col-md-3">
       <h2>Explore the API</h2>
       <p>Jump right into the self-documenting API.</p>
-      <p><a class="btn btn-default" href="{{ url('api-root') }}" role="button">API &raquo;</a></p>
+      <p><a class="btn btn-default" href="{{ url('v1:api-root') }}" role="button">API &raquo;</a></p>
     </div>
     <div class="col-md-3">
       <h2>Import from MDN</h2>

--- a/webplatformcompat/pagination.py
+++ b/webplatformcompat/pagination.py
@@ -1,0 +1,10 @@
+"""Pagination for webplatformcompat viewsets."""
+# -*- coding: utf-8 -*-
+
+from rest_framework.pagination import PageNumberPagination
+
+
+class Pagination(PageNumberPagination):
+    """Allow overriding the page size."""
+    page_size_query_param = 'page_size'
+    max_page_size = 1000

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -12,14 +12,13 @@ from webplatformcompat.history import Changeset
 class TestMixin(object):
     """Useful methods for testing"""
     maxDiff = None
-    baseUrl = 'http://testserver'
 
     def tearDown(self):
         cache.clear()
 
-    def reverse(self, viewname, **kwargs):
-        """Create a full URL for a view"""
-        return self.baseUrl + reverse(viewname, kwargs=kwargs)
+    def api_reverse(self, viewname, **kwargs):
+        """Create a path to an API view"""
+        return reverse(viewname, kwargs=kwargs)
 
     def login_user(self, groups=None):
         """Create and login a user, saving to self.user.

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -12,13 +12,14 @@ from webplatformcompat.history import Changeset
 class TestMixin(object):
     """Useful methods for testing"""
     maxDiff = None
+    namespace = 'v1'
 
     def tearDown(self):
         cache.clear()
 
     def api_reverse(self, viewname, **kwargs):
-        """Create a path to an API view"""
-        return reverse(viewname, kwargs=kwargs)
+        """Create a path to a namespaced API view."""
+        return reverse("%s:%s" % (self.namespace, viewname), kwargs=kwargs)
 
     def login_user(self, groups=None):
         """Create and login a user, saving to self.user.

--- a/webplatformcompat/tests/test_history.py
+++ b/webplatformcompat/tests/test_history.py
@@ -5,7 +5,6 @@
 from json import loads
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 
 from webplatformcompat.history import Changeset
 from webplatformcompat.models import Browser
@@ -19,7 +18,7 @@ class TestHistoryChangesetRequestMiddleware(APITestCase):
     def test_post_with_changeset(self):
         self.login_user()
         changeset = Changeset.objects.create(user=self.user)
-        url = reverse('browser-list') + '?changeset=%s' % changeset.id
+        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
         response = self.client.post(url, data)
         self.assertEqual(201, response.status_code, response.data)
@@ -31,7 +30,7 @@ class TestHistoryChangesetRequestMiddleware(APITestCase):
         self.login_user()
         other = User.objects.create(username='other')
         changeset = Changeset.objects.create(user=other)
-        url = reverse('browser-list') + '?changeset=%s' % changeset.id
+        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
         response = self.client.post(
             url, data, content_type="application/vnd.api+json")
@@ -47,7 +46,7 @@ class TestHistoryChangesetRequestMiddleware(APITestCase):
     def test_post_with_closed_changeset(self):
         self.login_user()
         changeset = Changeset.objects.create(user=self.user, closed=True)
-        url = reverse('browser-list') + '?changeset=%s' % changeset.id
+        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
         response = self.client.post(
             url, data, content_type="application/vnd.api+json")
@@ -60,7 +59,7 @@ class TestHistoryChangesetRequestMiddleware(APITestCase):
     def test_post_with_error_not_json_api(self):
         self.login_user()
         changeset = Changeset.objects.create(user=self.user, closed=True)
-        url = reverse('browser-list') + '?changeset=%s' % changeset.id
+        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
         response = self.client.post(url, data)
         self.assertEqual(400, response.status_code)

--- a/webplatformcompat/tests/test_serializers.py
+++ b/webplatformcompat/tests/test_serializers.py
@@ -4,8 +4,6 @@
 
 from json import dumps
 
-from django.core.urlresolvers import reverse
-
 from webplatformcompat.models import (
     Browser, Feature, Maturity, Section, Specification, Version)
 
@@ -39,7 +37,7 @@ class TestHistoricalModelSerializer(APITestCase):
     def setUp(self):
         self.browser = self.create(
             Browser, slug='browser', name={'en': 'Old Name'})
-        self.url = reverse('browser-detail', kwargs={'pk': self.browser.pk})
+        self.url = self.api_reverse('browser-detail', pk=self.browser.pk)
 
     def test_put_history_current(self):
         old_history_id = self.browser.history.latest('history_date').history_id
@@ -121,7 +119,7 @@ class TestBrowserSerializer(APITestCase):
             Browser, slug='browser', name={'en': 'Browser'})
         self.v1 = self.create(Version, browser=self.browser, version='1.0')
         self.v2 = self.create(Version, browser=self.browser, version='2.0')
-        self.url = reverse('browser-detail', kwargs={'pk': self.browser.pk})
+        self.url = self.api_reverse('browser-detail', pk=self.browser.pk)
 
     def test_versions_change_order(self):
         data = {
@@ -158,7 +156,7 @@ class TestFeatureSerializer(APITestCase):
         self.feature = self.create(Feature, slug='feature', parent=self.parent)
         self.child1 = self.create(Feature, slug='child1', parent=self.feature)
         self.child2 = self.create(Feature, slug='child2', parent=self.feature)
-        self.url = reverse('feature-detail', kwargs={'pk': self.feature.pk})
+        self.url = self.api_reverse('feature-detail', pk=self.feature.pk)
 
     def test_original_order(self):
         response = self.get_via_json_api(self.url)
@@ -244,7 +242,7 @@ class TestSpecificationSerializer(APITestCase):
             Section, specification=self.spec,
             name={'en': "The 'animation-iteration-count' property"},
             subpath={'en': "#animation-iteration-count"})
-        self.url = reverse('specification-detail', kwargs={'pk': self.spec.pk})
+        self.url = self.api_reverse('specification-detail', pk=self.spec.pk)
 
     def test_update_without_sections(self):
         data = {
@@ -312,7 +310,7 @@ class TestUserSerializer(APITestCase):
     """Test UserSerializer through the view."""
     def test_get(self):
         self.login_user()
-        url = reverse('user-detail', kwargs={'pk': self.user.pk})
+        url = self.api_reverse('user-detail', pk=self.user.pk)
         response = self.get_via_json_api(url)
         actual_data = response.data
         self.assertEqual(0, actual_data['agreement'])
@@ -325,7 +323,7 @@ class TestHistoricalFeatureSerializer(APITestCase):
         feature = self.create(
             Feature, slug="the_feature", name={"en": "The Feature"})
         history = feature.history.all()[0]
-        url = reverse('historicalfeature-detail', kwargs={'pk': history.pk})
+        url = self.api_reverse('historicalfeature-detail', pk=history.pk)
         response = self.get_via_json_api(url)
         actual_sections = response.data['features']['links']['sections']
         self.assertEqual([], actual_sections)
@@ -339,7 +337,7 @@ class TestHistoricalFeatureSerializer(APITestCase):
             Feature, slug="the_feature", name={"en": "The Feature"},
             parent=parent)
         history = feature.history.all()[0]
-        url = reverse('historicalfeature-detail', kwargs={'pk': history.pk})
+        url = self.api_reverse('historicalfeature-detail', pk=history.pk)
         response = self.get_via_json_api(url)
         expected_parent = str(parent.pk)
         actual_parent = response.data['features']['links']['parent']

--- a/webplatformcompat/tests/test_views.py
+++ b/webplatformcompat/tests/test_views.py
@@ -13,35 +13,44 @@ class TestViews(TestCase):
         response = self.client.get('')
         self.assertEqual(response.status_code, 200)
 
+    def full_api_reverse(self, viewname):
+        """Create a full URL for a namespaced API view."""
+        return 'http://testserver' + self.api_reverse(viewname)
+
     def test_api_root(self):
-        response = self.client.get(reverse('api-root'))
+        response = self.client.get(self.api_reverse('api-root'))
         expected = {
             'resources': {
-                'browsers': self.reverse('browser-list'),
-                'features': self.reverse('feature-list'),
-                'maturities': self.reverse('maturity-list'),
-                'specifications': self.reverse('specification-list'),
-                'sections': self.reverse('section-list'),
-                'supports': self.reverse('support-list'),
-                'versions': self.reverse('version-list'),
+                'browsers': self.full_api_reverse('browser-list'),
+                'features': self.full_api_reverse('feature-list'),
+                'maturities': self.full_api_reverse('maturity-list'),
+                'specifications': self.full_api_reverse('specification-list'),
+                'sections': self.full_api_reverse('section-list'),
+                'supports': self.full_api_reverse('support-list'),
+                'versions': self.full_api_reverse('version-list'),
             },
             'change_control': {
-                'changesets': self.reverse('changeset-list'),
-                'users': self.reverse('user-list'),
+                'changesets': self.full_api_reverse('changeset-list'),
+                'users': self.full_api_reverse('user-list'),
             },
             'history': {
-                'historical_browsers': self.reverse('historicalbrowser-list'),
-                'historical_features': self.reverse('historicalfeature-list'),
-                'historical_maturities': self.reverse(
+                'historical_browsers': self.full_api_reverse(
+                    'historicalbrowser-list'),
+                'historical_features': self.full_api_reverse(
+                    'historicalfeature-list'),
+                'historical_maturities': self.full_api_reverse(
                     'historicalmaturity-list'),
-                'historical_sections': self.reverse('historicalsection-list'),
-                'historical_specifications': self.reverse(
+                'historical_sections': self.full_api_reverse(
+                    'historicalsection-list'),
+                'historical_specifications': self.full_api_reverse(
                     'historicalspecification-list'),
-                'historical_supports': self.reverse('historicalsupport-list'),
-                'historical_versions': self.reverse('historicalversion-list'),
+                'historical_supports': self.full_api_reverse(
+                    'historicalsupport-list'),
+                'historical_versions': self.full_api_reverse(
+                    'historicalversion-list'),
             },
             'views': {
-                'view_features': self.reverse('viewfeatures-list')
+                'view_features': self.full_api_reverse('viewfeatures-list')
             },
         }
         actual = loads(response.content.decode('utf-8'))

--- a/webplatformcompat/tests/test_viewsets.py
+++ b/webplatformcompat/tests/test_viewsets.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from json import dumps, loads
 from pytz import UTC
 
-from django.core.urlresolvers import reverse
 import mock
 
 from webplatformcompat.history import Changeset
@@ -24,7 +23,7 @@ class TestGenericViewset(APITestCase):
             slug="firefox",
             name={"en": "Firefox"},
             note={"en": "Uses Gecko for its web browser engine"})
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         response = self.client.get(url)
         history_pk = browser.history.get().pk
         expected_content = {
@@ -69,7 +68,7 @@ class TestGenericViewset(APITestCase):
             slug="firefox", name={"en": "Firefox"},
             note={"en": "Uses Gecko for its web browser engine"})
         chrome = self.create(Browser, slug="chrome", name={"en": "Chrome"})
-        response = self.client.get(reverse('browser-list'))
+        response = self.client.get(self.api_reverse('browser-list'))
         firefox_history_id = str(firefox.history.get().pk)
         chrome_history_id = str(chrome.history.get().pk)
         expected_content = {
@@ -131,7 +130,7 @@ class TestGenericViewset(APITestCase):
 
     def test_get_browsable_api(self):
         browser = self.create(Browser)
-        url = self.reverse('browser-list')
+        url = self.api_reverse('browser-list')
         response = self.client.get(url, HTTP_ACCEPT="text/html")
         history_pk = browser.history.get().pk
         expected_data = {
@@ -153,7 +152,7 @@ class TestGenericViewset(APITestCase):
     def test_post_minimal(self):
         self.login_user()
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
-        response = self.client.post(reverse('browser-list'), data)
+        response = self.client.post(self.api_reverse('browser-list'), data)
         self.assertEqual(201, response.status_code, response.data)
         browser = Browser.objects.get()
         history_pk = browser.history.get().pk
@@ -180,7 +179,7 @@ class TestGenericViewset(APITestCase):
                 }
             }
         })
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         mock_update.reset_mock()
         response = self.client.put(
             url, data=data, content_type="application/vnd.api+json")
@@ -210,7 +209,7 @@ class TestGenericViewset(APITestCase):
                 }
             }
         })
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         url += '?changeset=%s' % changeset.pk
         mock_update.reset_mock()
         mock_update.side_effect = Exception("not called")
@@ -223,7 +222,7 @@ class TestGenericViewset(APITestCase):
         browser = self.create(
             Browser, slug='browser', name={'en': 'Old Name'})
         data = {'name': '{"en": "New Name"}'}
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         response = self.client.put(url, data=data)
         self.assertEqual(200, response.status_code, response.data)
         histories = browser.history.all()
@@ -242,7 +241,7 @@ class TestGenericViewset(APITestCase):
     def test_delete(self, mock_update):
         self.login_user(groups=["change-resource", "delete-resource"])
         browser = self.create(Browser, slug='firesux', name={'en': 'Firesux'})
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         mock_update.reset_mock()
         response = self.client.delete(url)
         self.assertEqual(204, response.status_code, response.content)
@@ -253,7 +252,7 @@ class TestGenericViewset(APITestCase):
         self.login_user()
         browser = self.create(
             Browser, slug='browser', name={'en': 'Old Name'})
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         response = self.client.delete(url)
         self.assertEqual(403, response.status_code)
         expected_data = {
@@ -267,7 +266,7 @@ class TestGenericViewset(APITestCase):
         browser = self.create(
             Browser, slug="internet_exploder",
             name={'en': 'Internet Exploder'})
-        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        url = self.api_reverse('browser-detail', pk=browser.pk)
         url += "?changeset=%d" % self.changeset.id
         mock_update.reset_mock()
         mock_update.side_effect = Exception("not called")
@@ -308,36 +307,34 @@ class TestCascadeDelete(APITestCase):
         self.assertEqual(features, Feature.objects.count())
 
     def test_delete_browser(self):
-        url = reverse('browser-detail', kwargs={'pk': self.browser.pk})
+        url = self.api_reverse('browser-detail', pk=self.browser.pk)
         self.assert_counts_after_delete(
             url, browsers=0, versions=0, supports=0)
 
     def test_delete_version(self):
-        url = reverse('version-detail', kwargs={'pk': self.version.pk})
+        url = self.api_reverse('version-detail', pk=self.version.pk)
         self.assert_counts_after_delete(url, versions=0, supports=0)
 
     def test_delete_support(self):
-        url = reverse('support-detail', kwargs={'pk': self.support.pk})
+        url = self.api_reverse('support-detail', pk=self.support.pk)
         self.assert_counts_after_delete(url, supports=0)
 
     def test_delete_maturity(self):
-        url = reverse('maturity-detail', kwargs={'pk': self.maturity.pk})
+        url = self.api_reverse('maturity-detail', pk=self.maturity.pk)
         self.assert_counts_after_delete(
             url, maturities=0, specifications=0, sections=0)
 
     def test_delete_specification(self):
-        url = reverse(
-            'specification-detail', kwargs={'pk': self.specification.pk})
+        url = self.api_reverse(
+            'specification-detail', pk=self.specification.pk)
         self.assert_counts_after_delete(url, specifications=0, sections=0)
 
     def test_delete_section(self):
-        url = reverse(
-            'section-detail', kwargs={'pk': self.section.pk})
+        url = self.api_reverse('section-detail', pk=self.section.pk)
         self.assert_counts_after_delete(url, sections=0)
 
     def test_delete_feature(self):
-        url = reverse(
-            'feature-detail', kwargs={'pk': self.parent.pk})
+        url = self.api_reverse('feature-detail', pk=self.parent.pk)
         self.assert_counts_after_delete(url, features=0, supports=0)
 
 
@@ -349,7 +346,7 @@ class TestFeatureViewSet(APITestCase):
             Feature, slug='feature', parent=parent, name={'en': 'A Feature'})
         self.create(Feature, slug="other", name={'en': 'Other'})
         response = self.client.get(
-            reverse('feature-list'), {'slug': 'feature'})
+            self.api_reverse('feature-list'), {'slug': 'feature'})
         self.assertEqual(200, response.status_code, response.data)
         self.assertEqual(1, response.data['count'])
         self.assertEqual(feature.id, response.data['results'][0]['id'])
@@ -360,7 +357,7 @@ class TestFeatureViewSet(APITestCase):
             Feature, slug='feature', parent=parent, name={'en': 'A Feature'})
         self.create(Feature, slug="other", name={'en': 'Other'})
         response = self.client.get(
-            reverse('feature-list'), {'parent': str(parent.id)})
+            self.api_reverse('feature-list'), {'parent': str(parent.id)})
         self.assertEqual(200, response.status_code, response.data)
         self.assertEqual(1, response.data['count'])
         self.assertEqual(feature.id, response.data['results'][0]['id'])
@@ -370,7 +367,8 @@ class TestFeatureViewSet(APITestCase):
         self.create(
             Feature, slug='feature', parent=parent, name={'en': 'The Feature'})
         other = self.create(Feature, slug="other", name={'en': 'Other'})
-        response = self.client.get(reverse('feature-list'), {'parent': ''})
+        response = self.client.get(
+            self.api_reverse('feature-list'), {'parent': ''})
         self.assertEqual(200, response.status_code, response.data)
         self.assertEqual(2, response.data['count'])
         self.assertEqual(parent.id, response.data['results'][0]['id'])
@@ -384,7 +382,7 @@ class TestHistoricaViewset(APITestCase):
             Browser, slug='browser', name={'en': 'A Browser'},
             _history_date=datetime(2014, 8, 25, 20, 50, 38, 868903, UTC))
         history = browser.history.all()[0]
-        url = reverse('historicalbrowser-detail', kwargs={'pk': history.pk})
+        url = self.api_reverse('historicalbrowser-detail', pk=history.pk)
         response = self.client.get(
             url, HTTP_ACCEPT="application/vnd.api+json")
         self.assertEqual(200, response.status_code, response.data)

--- a/webplatformcompat/urls.py
+++ b/webplatformcompat/urls.py
@@ -21,7 +21,7 @@ webplatformcompat_urlpatterns = patterns(
         namespace='rest_framework')),
     url(r'^api/$', RedirectView.as_view(url='/api/v1/', permanent=False),
         name='api_root'),
-    url(r'^api/v1/', include(router.urls)),
+    url(r'^api/v1/', include(router.urls, namespace='v1')),
     url(r'^importer$', RedirectView.as_view(
         url='/importer/', permanent=False)),
     url(r'^importer/', include(mdn_urlpatterns)),

--- a/webplatformcompat/view_serializers.py
+++ b/webplatformcompat/view_serializers.py
@@ -81,6 +81,8 @@ class ViewFeatureListSerializer(FieldMapMixin, ModelSerializer):
 
 class DjangoResourceClient(object):
     """Implement tools.client.Client using Django native functions"""
+    namespace = 'v1'
+
     def url(self, resource_type, resource_id=None):
         """Use Django reverse to determine URL."""
         if resource_type == 'maturities':
@@ -89,9 +91,10 @@ class DjangoResourceClient(object):
             singular = resource_type[:-1]
         if resource_id:
             return reverse(
-                singular + '-detail', kwargs={'pk': resource_id})
+                self.namespace + ':' + singular + '-detail',
+                kwargs={'pk': resource_id})
         else:
-            return reverse(singular + '-list')
+            return reverse(self.namespace + ':' + singular + '-list')
 
     def open_changeset(self):
         """Skip opening changesets (opened at the request/view level)."""

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -327,9 +327,8 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': [
         'webplatformcompat.filters.UnorderedDjangoFilterBackend',
     ],
-    'PAGINATE_BY': 10,
-    'PAGINATE_BY_PARAM': 'page_size',
-    'MAX_PAGINATE_BY': 100,
+    'DEFAULT_PAGINATION_CLASS': 'webplatformcompat.pagination.Pagination',
+    'PAGE_SIZE': 10,
 }
 
 # Django nose

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -329,6 +329,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'webplatformcompat.pagination.Pagination',
     'PAGE_SIZE': 10,
+    'DEFAULT_VERSIONING_CLASS': (
+        'rest_framework.versioning.NamespaceVersioning'),
 }
 
 # Django nose


### PR DESCRIPTION
This PR bumps requirements to [latest versions](https://requires.io/github/mdn/browsercompat/requirements/?branch=update_reqs_1153288), including Django REST Framework 3.3 (which may enable a better browsable API eventually).

Then, it namespaces the v1 API views.  This has no effect outside the code, but will lay the foundation for  supporting a v2 API at the same time.