### PR TITLE
fix bug 1224381 - Poll import every 1 second

### DIFF
--- a/mdn/jinja2/mdn/feature_page_detail.html
+++ b/mdn/jinja2/mdn/feature_page_detail.html
@@ -308,17 +308,13 @@ function load_json(data) {
     window.resources = resources = WPC.parse_resources(data);
     load_tables(window.resources, "en");
     $("#form-commit").on('submit', commit_json);
-
-    if (isProcessing(data)) {
-        pollServer();
-    }
 };
 
 function pollServer() {
     $.getJSON(import_uri).done(function( data ) {
         load_json(data);
         if (isProcessing(data)) {
-            setTimeout(fetch_json, 1000);
+            setTimeout(pollServer, 1000);
         } else {
             window.location.reload(true);
         }
@@ -331,6 +327,9 @@ import_uri = "{{ url('feature_page_json', pk=object.id) }}";
 $( document ).ready(function () {
     if (data) {
         load_json(data);
+        if (isProcessing(data)) {
+            pollServer();
+        }
     }
 });
 </script>


### PR DESCRIPTION
When running a long import, poll the server to see if the import is complete every second, instead of immediately after getting the last poll response (several times a second).

[Bug 1224381](https://bugzilla.mozilla.org/show_bug.cgi?id=1224381) is fixed - [Web/API/KeyboardEvent/key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) now [imports](https://browsercompat.herokuapp.com/importer/2519) - but it also attempts a denial-of-service attack while it is waiting for the parse to complete.