### PR TITLE
bug 1159406 - Fix importer for namespaced API

### DIFF
--- a/mdn/jinja2/mdn/feature_page_detail.html
+++ b/mdn/jinja2/mdn/feature_page_detail.html
@@ -138,7 +138,7 @@
 {% endif %}
 {% if can_commit_mdn_import(request.user) and object.errors == 0 and object.critical == 0 %}
 <form id="form-commit" method="put"
- action="{{ url('viewfeatures-detail', pk=object.feature_id) }}">
+ action="{{ url('v1:viewfeatures-detail', pk=object.feature_id) }}">
 {{ csrf_input }}
 <input id="submit-commit" class="btn btn-primary" type="submit" value="Commit">
 <label for="submit-commit" id="submit-commit-label">Commit data to the API</label>
@@ -179,8 +179,8 @@
   <a href="{{ url('feature_page_json', pk=object.pk) }}">raw JSON-API data</a>
   resembles that returned from
   <code>
-    <a id="wpc_uri" href="/api/v1/view_features/{{ object.feature.id }}">
-      /api/v1/view_features/{{ object.feature.id }}
+    <a id="wpc_uri" href="{{ url('v1:viewfeatures-detail', pk=object.feature.id) }}">
+      {{ url('v1:viewfeatures-detail', pk=object.feature.id) }}
     </a>
   </code>
 </p>

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -153,6 +153,11 @@ class TestFeaturePageDetailView(TestCase):
         obj = response.context_data['object']
         self.assertEqual(obj.id, feature_page.id)
 
+    def test_can_commit_parsed(self):
+        # When accessed with privileged user, adds links to API
+        self.login_user(groups=['import-mdn', 'change-resource'])
+        self.test_get()
+
 
 class TestFeaturePageJSONView(TestCase):
     def test_get(self):


### PR DESCRIPTION
The importer includes links to the API when the user can commit data, and the reverse is broken with namespaced API URLs. This adds a test to use a privileged user to fetch the view, and fixes the template to use namespaced API URLs.