### PR TITLE
fix bug 1124356 - Improve UI for async commit

### DIFF
--- a/mdn/jinja2/mdn/feature_page_detail.html
+++ b/mdn/jinja2/mdn/feature_page_detail.html
@@ -265,7 +265,7 @@ function commit_json() {
     button = $("#submit-commit");
     button.removeClass("btn-primary").addClass("btn-disabled");
     label = $("#submit-commit-label");
-    label.html("<i>Committing data to the API...</i>");
+    label.html("<em>Committing data to the API...</em>");
     frm = $("#form-commit");
     csrf = $("input[name='csrfmiddlewaretoken']").val();
     jsonData = JSON.stringify(data);
@@ -277,13 +277,16 @@ function commit_json() {
         headers: {'X-CSRFToken': csrf},
         success: function(data, textStatus, jqXHR) {
             var form = $("#form-reparse");
+            label.html("<em>Loading new IDs from API...</em>");
             if (form.length) {
                 form.submit();
             } else {
                  $("#form-reset").submit();
             }
+            pollServer();
         },
         error: function(jqXHR, textStatus, errorThrown) {
+            label.html("Error commiting data to API!");
             $("#pre-commit-errors").html(jqXHR.responseText);
             $("#commit-errors").removeClass("hide");
         }
@@ -307,7 +310,6 @@ function load_json(data) {
     $("#wpc_data").html(json_dump);
     window.resources = resources = WPC.parse_resources(data);
     load_tables(window.resources, "en");
-    $("#form-commit").on('submit', commit_json);
 };
 
 function pollServer() {
@@ -327,6 +329,7 @@ import_uri = "{{ url('feature_page_json', pk=object.id) }}";
 $( document ).ready(function () {
     if (data) {
         load_json(data);
+        $("#form-commit").on('submit', commit_json);
         if (isProcessing(data)) {
             pollServer();
         }


### PR DESCRIPTION
When the server is in async mode, change text after a successful sync, and start polling the server to reload with new data IDs.

Also, only set the handler for the commit button during page setup.