### PR TITLE
fix bug 1153288 - Rewrite serializer, parser, renderer

### DIFF
--- a/bcauth/views.py
+++ b/bcauth/views.py
@@ -3,9 +3,8 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
+from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
-
-from webplatformcompat.views import RequestView
 
 
 class AccountView(RedirectView):
@@ -20,7 +19,7 @@ class AccountView(RedirectView):
         return super(AccountView, self).get_redirect_url(*args, **kwargs)
 
 
-class ProfileView(RequestView):
+class ProfileView(TemplateView):
     template_name = 'account/profile.html'
 
 

--- a/docs/v1/doc_cases.json
+++ b/docs/v1/doc_cases.json
@@ -1094,5 +1094,13 @@
                 }
             }
         }
+    }, {
+        "name": "browser-list-options",
+        "method": "OPTIONS",
+        "endpoint": "browsers"
+    }, {
+        "name": "browser-detail-options",
+        "method": "OPTIONS",
+        "endpoint": "browsers/7"
     }
 ]

--- a/docs/v1/raw/browser-by-id-response-body.json
+++ b/docs/v1/raw/browser-by-id-response-body.json
@@ -7,31 +7,31 @@
         },
         "note": null,
         "links": {
-            "history": [
-                "7"
-            ],
-            "history_current": "7",
             "versions": [
                 "17",
                 "18",
                 "19",
                 "20",
                 "21"
+            ],
+            "history_current": "7",
+            "history": [
+                "7"
             ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-by-slug-response-body.json
+++ b/docs/v1/raw/browser-by-slug-response-body.json
@@ -8,32 +8,32 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "7"
-                ],
-                "history_current": "7",
                 "versions": [
                     "17",
                     "18",
                     "19",
                     "20",
                     "21"
+                ],
+                "history_current": "7",
+                "history": [
+                    "7"
                 ]
             }
         }
     ],
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/browser-create-in-changeset-2-response-body.json
+++ b/docs/v1/raw/browser-create-in-changeset-2-response-body.json
@@ -8,25 +8,25 @@
         },
         "note": null,
         "links": {
+            "versions": [],
+            "history_current": "18",
             "history": [
                 "18"
-            ],
-            "history_current": "18",
-            "versions": []
+            ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-create-maximized-response-body.json
+++ b/docs/v1/raw/browser-create-maximized-response-body.json
@@ -9,25 +9,25 @@
             "en": "First comes the Navigator, then Explorer, and then the Konqueror."
         },
         "links": {
+            "versions": [],
+            "history_current": "17",
             "history": [
                 "17"
-            ],
-            "history_current": "17",
-            "versions": []
+            ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-create-minimal-response-body.json
+++ b/docs/v1/raw/browser-create-minimal-response-body.json
@@ -7,25 +7,25 @@
         },
         "note": null,
         "links": {
+            "versions": [],
+            "history_current": "16",
             "history": [
                 "16"
-            ],
-            "history_current": "16",
-            "versions": []
+            ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-detail-options-request-headers.txt
+++ b/docs/v1/raw/browser-detail-options-request-headers.txt
@@ -1,0 +1,4 @@
+OPTIONS /api/v1/browsers/7 HTTP/1.1
+Host: browsercompat.org
+Accept: application/vnd.api+json
+Content-Length: 0

--- a/docs/v1/raw/browser-detail-options-response-body.json
+++ b/docs/v1/raw/browser-detail-options-response-body.json
@@ -1,0 +1,15 @@
+{
+    "meta": {
+        "name": "Browser",
+        "description": "",
+        "renders": [
+            "application/vnd.api+json",
+            "text/html"
+        ],
+        "parses": [
+            "application/vnd.api+json",
+            "application/x-www-form-urlencoded",
+            "multipart/form-data"
+        ]
+    }
+}

--- a/docs/v1/raw/browser-detail-options-response-headers.txt
+++ b/docs/v1/raw/browser-detail-options-response-headers.txt
@@ -1,0 +1,2 @@
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json

--- a/docs/v1/raw/browser-list-options-request-headers.txt
+++ b/docs/v1/raw/browser-list-options-request-headers.txt
@@ -1,0 +1,4 @@
+OPTIONS /api/v1/browsers HTTP/1.1
+Host: browsercompat.org
+Accept: application/vnd.api+json
+Content-Length: 0

--- a/docs/v1/raw/browser-list-options-response-body.json
+++ b/docs/v1/raw/browser-list-options-response-body.json
@@ -1,0 +1,15 @@
+{
+    "meta": {
+        "name": "Browser",
+        "description": "",
+        "renders": [
+            "application/vnd.api+json",
+            "text/html"
+        ],
+        "parses": [
+            "application/vnd.api+json",
+            "application/x-www-form-urlencoded",
+            "multipart/form-data"
+        ]
+    }
+}

--- a/docs/v1/raw/browser-list-options-response-headers.txt
+++ b/docs/v1/raw/browser-list-options-response-headers.txt
@@ -1,0 +1,2 @@
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json

--- a/docs/v1/raw/browser-list-page2-response-body.json
+++ b/docs/v1/raw/browser-list-page2-response-body.json
@@ -8,15 +8,15 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "11"
-                ],
-                "history_current": "11",
                 "versions": [
                     "33",
                     "34",
                     "35",
                     "36"
+                ],
+                "history_current": "11",
+                "history": [
+                    "11"
                 ]
             }
         },
@@ -28,12 +28,12 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "12"
-                ],
-                "history_current": "12",
                 "versions": [
                     "37"
+                ],
+                "history_current": "12",
+                "history": [
+                    "12"
                 ]
             }
         },
@@ -45,14 +45,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "13"
-                ],
-                "history_current": "13",
                 "versions": [
                     "38",
                     "39",
                     "40"
+                ],
+                "history_current": "13",
+                "history": [
+                    "13"
                 ]
             }
         },
@@ -64,15 +64,15 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "14"
-                ],
-                "history_current": "14",
                 "versions": [
                     "41",
                     "42",
                     "43",
                     "44"
+                ],
+                "history_current": "14",
+                "history": [
+                    "14"
                 ]
             }
         },
@@ -84,30 +84,30 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "15"
-                ],
-                "history_current": "15",
                 "versions": [
                     "45",
                     "46",
                     "47"
+                ],
+                "history_current": "15",
+                "history": [
+                    "15"
                 ]
             }
         }
     ],
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/browser-list-response-body.json
+++ b/docs/v1/raw/browser-list-response-body.json
@@ -8,14 +8,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "1"
-                ],
-                "history_current": "1",
                 "versions": [
                     "1",
                     "2",
                     "3"
+                ],
+                "history_current": "1",
+                "history": [
+                    "1"
                 ]
             }
         },
@@ -27,12 +27,12 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "2"
-                ],
-                "history_current": "2",
                 "versions": [
                     "4"
+                ],
+                "history_current": "2",
+                "history": [
+                    "2"
                 ]
             }
         },
@@ -44,14 +44,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "3"
-                ],
-                "history_current": "3",
                 "versions": [
                     "5",
                     "6",
                     "7"
+                ],
+                "history_current": "3",
+                "history": [
+                    "3"
                 ]
             }
         },
@@ -63,14 +63,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "4"
-                ],
-                "history_current": "4",
                 "versions": [
                     "8",
                     "9",
                     "10"
+                ],
+                "history_current": "4",
+                "history": [
+                    "4"
                 ]
             }
         },
@@ -82,14 +82,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "5"
-                ],
-                "history_current": "5",
                 "versions": [
                     "11",
                     "12",
                     "13"
+                ],
+                "history_current": "5",
+                "history": [
+                    "5"
                 ]
             }
         },
@@ -101,14 +101,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "6"
-                ],
-                "history_current": "6",
                 "versions": [
                     "14",
                     "15",
                     "16"
+                ],
+                "history_current": "6",
+                "history": [
+                    "6"
                 ]
             }
         },
@@ -120,16 +120,16 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "7"
-                ],
-                "history_current": "7",
                 "versions": [
                     "17",
                     "18",
                     "19",
                     "20",
                     "21"
+                ],
+                "history_current": "7",
+                "history": [
+                    "7"
                 ]
             }
         },
@@ -141,14 +141,14 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "8"
-                ],
-                "history_current": "8",
                 "versions": [
                     "22",
                     "23",
                     "24"
+                ],
+                "history_current": "8",
+                "history": [
+                    "8"
                 ]
             }
         },
@@ -160,16 +160,16 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "9"
-                ],
-                "history_current": "9",
                 "versions": [
                     "25",
                     "26",
                     "27",
                     "28",
                     "29"
+                ],
+                "history_current": "9",
+                "history": [
+                    "9"
                 ]
             }
         },
@@ -181,30 +181,30 @@
             },
             "note": null,
             "links": {
-                "history": [
-                    "10"
-                ],
-                "history_current": "10",
                 "versions": [
                     "30",
                     "31",
                     "32"
+                ],
+                "history_current": "10",
+                "history": [
+                    "10"
                 ]
             }
         }
     ],
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/browser-revert-response-body.json
+++ b/docs/v1/raw/browser-revert-response-body.json
@@ -7,35 +7,35 @@
         },
         "note": null,
         "links": {
-            "history": [
-                "22",
-                "21",
-                "20",
-                "19",
-                "9"
-            ],
-            "history_current": "22",
             "versions": [
                 "25",
                 "26",
                 "27",
                 "29",
                 "28"
+            ],
+            "history_current": "22",
+            "history": [
+                "22",
+                "21",
+                "20",
+                "19",
+                "9"
             ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-update-full-response-body.json
+++ b/docs/v1/raw/browser-update-full-response-body.json
@@ -7,32 +7,32 @@
         },
         "note": null,
         "links": {
-            "history": [
-                "19",
-                "9"
-            ],
-            "history_current": "19",
             "versions": [
                 "25",
                 "26",
                 "27",
                 "28",
                 "29"
+            ],
+            "history_current": "19",
+            "history": [
+                "19",
+                "9"
             ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-update-partial-response-body.json
+++ b/docs/v1/raw/browser-update-partial-response-body.json
@@ -7,33 +7,33 @@
         },
         "note": null,
         "links": {
-            "history": [
-                "20",
-                "19",
-                "9"
-            ],
-            "history_current": "20",
             "versions": [
                 "25",
                 "26",
                 "27",
                 "28",
                 "29"
+            ],
+            "history_current": "20",
+            "history": [
+                "20",
+                "19",
+                "9"
             ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/browser-update-versions-order-response-body.json
+++ b/docs/v1/raw/browser-update-versions-order-response-body.json
@@ -7,34 +7,34 @@
         },
         "note": null,
         "links": {
-            "history": [
-                "21",
-                "20",
-                "19",
-                "9"
-            ],
-            "history_current": "21",
             "versions": [
                 "25",
                 "26",
                 "27",
                 "29",
                 "28"
+            ],
+            "history_current": "21",
+            "history": [
+                "21",
+                "20",
+                "19",
+                "9"
             ]
         }
     },
     "links": {
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
+        "browsers.versions": {
+            "type": "versions",
+            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
         },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
         },
-        "browsers.versions": {
-            "type": "versions",
-            "href": "https://browsercompat.org/api/v1/versions/{browsers.versions}"
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         }
     }
 }

--- a/docs/v1/raw/feature-add-sections-05-response-body.json
+++ b/docs/v1/raw/feature-add-sections-05-response-body.json
@@ -11,10 +11,10 @@
             "en": "HTML"
         },
         "links": {
-            "sections": [],
-            "supports": [],
             "parent": "1",
             "children": [],
+            "sections": [],
+            "supports": [],
             "history_current": "18",
             "history": [
                 "18"
@@ -22,14 +22,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -37,6 +29,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-add-sections-06-response-body.json
+++ b/docs/v1/raw/feature-add-sections-06-response-body.json
@@ -11,10 +11,10 @@
             "en": "Element"
         },
         "links": {
-            "sections": [],
-            "supports": [],
             "parent": "16",
             "children": [],
+            "sections": [],
+            "supports": [],
             "history_current": "19",
             "history": [
                 "19"
@@ -22,14 +22,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -37,6 +29,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-add-sections-07-response-body.json
+++ b/docs/v1/raw/feature-add-sections-07-response-body.json
@@ -11,10 +11,10 @@
         "obsolete": false,
         "name": "audio",
         "links": {
-            "sections": [],
-            "supports": [],
             "parent": "17",
             "children": [],
+            "sections": [],
+            "supports": [],
             "history_current": "20",
             "history": [
                 "20"
@@ -22,14 +22,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -37,6 +29,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-add-sections-08-response-body.json
+++ b/docs/v1/raw/feature-add-sections-08-response-body.json
@@ -11,12 +11,12 @@
         "obsolete": false,
         "name": "audio",
         "links": {
+            "parent": "17",
+            "children": [],
             "sections": [
                 "7"
             ],
             "supports": [],
-            "parent": "17",
-            "children": [],
             "history_current": "21",
             "history": [
                 "21",
@@ -25,14 +25,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -40,6 +32,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-add-sections-09-response-body.json
+++ b/docs/v1/raw/feature-add-sections-09-response-body.json
@@ -11,13 +11,13 @@
         "obsolete": false,
         "name": "audio",
         "links": {
+            "parent": "17",
+            "children": [],
             "sections": [
                 "7",
                 "6"
             ],
             "supports": [],
-            "parent": "17",
-            "children": [],
             "history_current": "22",
             "history": [
                 "22",
@@ -27,14 +27,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -42,6 +34,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-add-sections-10-response-body.json
+++ b/docs/v1/raw/feature-add-sections-10-response-body.json
@@ -11,13 +11,13 @@
         "obsolete": false,
         "name": "audio",
         "links": {
+            "parent": "17",
+            "children": [],
             "sections": [
                 "6",
                 "7"
             ],
             "supports": [],
-            "parent": "17",
-            "children": [],
             "history_current": "23",
             "history": [
                 "23",
@@ -28,14 +28,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -43,6 +35,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-by-id-canonical-response-body.json
+++ b/docs/v1/raw/feature-by-id-canonical-response-body.json
@@ -14,15 +14,15 @@
         "obsolete": false,
         "name": "transform-origin",
         "links": {
-            "sections": [
-                "4"
-            ],
-            "supports": [],
             "parent": "2",
             "children": [
                 "11",
                 "12"
             ],
+            "sections": [
+                "4"
+            ],
+            "supports": [],
             "history_current": "10",
             "history": [
                 "10"
@@ -30,14 +30,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -45,6 +37,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-by-id-response-body.json
+++ b/docs/v1/raw/feature-by-id-response-body.json
@@ -13,6 +13,8 @@
             "ja": "3-値構文"
         },
         "links": {
+            "parent": "10",
+            "children": [],
             "sections": [],
             "supports": [
                 "20",
@@ -23,8 +25,6 @@
                 "25",
                 "26"
             ],
-            "parent": "10",
-            "children": [],
             "history_current": "12",
             "history": [
                 "12"
@@ -32,14 +32,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -47,6 +39,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-by-no-parent-response-body.json
+++ b/docs/v1/raw/feature-by-no-parent-response-body.json
@@ -12,12 +12,12 @@
                 "en": "Web"
             },
             "links": {
-                "sections": [],
-                "supports": [],
                 "parent": null,
                 "children": [
                     "2"
                 ],
+                "sections": [],
+                "supports": [],
                 "history_current": "1",
                 "history": [
                     "1"
@@ -26,14 +26,6 @@
         }
     ],
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -41,6 +33,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-by-parent-response-body.json
+++ b/docs/v1/raw/feature-by-parent-response-body.json
@@ -15,6 +15,8 @@
                 "ja": "基本サポート"
             },
             "links": {
+                "parent": "10",
+                "children": [],
                 "sections": [],
                 "supports": [
                     "11",
@@ -27,8 +29,6 @@
                     "18",
                     "19"
                 ],
-                "parent": "10",
-                "children": [],
                 "history_current": "11",
                 "history": [
                     "11"
@@ -49,6 +49,8 @@
                 "ja": "3-値構文"
             },
             "links": {
+                "parent": "10",
+                "children": [],
                 "sections": [],
                 "supports": [
                     "20",
@@ -59,8 +61,6 @@
                     "25",
                     "26"
                 ],
-                "parent": "10",
-                "children": [],
                 "history_current": "12",
                 "history": [
                     "12"
@@ -69,14 +69,6 @@
         }
     ],
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -84,6 +76,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-by-slug-response-body.json
+++ b/docs/v1/raw/feature-by-slug-response-body.json
@@ -15,15 +15,15 @@
             "obsolete": false,
             "name": "transform-origin",
             "links": {
-                "sections": [
-                    "4"
-                ],
-                "supports": [],
                 "parent": "2",
                 "children": [
                     "11",
                     "12"
                 ],
+                "sections": [
+                    "4"
+                ],
+                "supports": [],
                 "history_current": "10",
                 "history": [
                     "10"
@@ -32,14 +32,6 @@
         }
     ],
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -47,6 +39,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-create-maximized-response-body.json
+++ b/docs/v1/raw/feature-create-maximized-response-body.json
@@ -11,10 +11,10 @@
             "en": "<code>ruby</code>, <code>ruby-base</code>, <code>ruby-text</code>, <code>ruby-base-container</code>, <code>ruby-text-container</code>"
         },
         "links": {
-            "sections": [],
-            "supports": [],
             "parent": "14",
             "children": [],
+            "sections": [],
+            "supports": [],
             "history_current": "15",
             "history": [
                 "15"
@@ -22,14 +22,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -37,6 +29,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-create-minimal-response-body.json
+++ b/docs/v1/raw/feature-create-minimal-response-body.json
@@ -9,10 +9,10 @@
         "obsolete": false,
         "name": "display",
         "links": {
-            "sections": [],
-            "supports": [],
             "parent": null,
             "children": [],
+            "sections": [],
+            "supports": [],
             "history_current": "14",
             "history": [
                 "14"
@@ -20,14 +20,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -35,6 +27,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-revert-response-body.json
+++ b/docs/v1/raw/feature-revert-response-body.json
@@ -13,6 +13,8 @@
             "ja": "3-値構文"
         },
         "links": {
+            "parent": "10",
+            "children": [],
             "sections": [],
             "supports": [
                 "20",
@@ -23,8 +25,6 @@
                 "25",
                 "26"
             ],
-            "parent": "10",
-            "children": [],
             "history_current": "27",
             "history": [
                 "27",
@@ -34,14 +34,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -49,6 +41,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-set-children-order-response-body.json
+++ b/docs/v1/raw/feature-set-children-order-response-body.json
@@ -11,8 +11,6 @@
             "en": "CSS"
         },
         "links": {
-            "sections": [],
-            "supports": [],
             "parent": "1",
             "children": [
                 "3",
@@ -24,6 +22,8 @@
                 "13",
                 "10"
             ],
+            "sections": [],
+            "supports": [],
             "history_current": "24",
             "history": [
                 "24",
@@ -32,14 +32,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -47,6 +39,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/feature-update-response-body.json
+++ b/docs/v1/raw/feature-update-response-body.json
@@ -13,6 +13,8 @@
             "ja": "3-値構文"
         },
         "links": {
+            "parent": "10",
+            "children": [],
             "sections": [],
             "supports": [
                 "20",
@@ -23,8 +25,6 @@
                 "25",
                 "26"
             ],
-            "parent": "10",
-            "children": [],
             "history_current": "16",
             "history": [
                 "16",
@@ -33,14 +33,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -48,6 +40,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",

--- a/docs/v1/raw/version-by-browser-response-body.json
+++ b/docs/v1/raw/version-by-browser-response-body.json
@@ -12,10 +12,10 @@
             "links": {
                 "browser": "7",
                 "supports": [],
+                "history_current": "17",
                 "history": [
                     "17"
-                ],
-                "history_current": "17"
+                ]
             }
         },
         {
@@ -32,10 +32,10 @@
                 "supports": [
                     "4"
                 ],
+                "history_current": "18",
                 "history": [
                     "18"
-                ],
-                "history_current": "18"
+                ]
             }
         },
         {
@@ -64,10 +64,10 @@
                 "supports": [
                     "13"
                 ],
+                "history_current": "19",
                 "history": [
                     "19"
-                ],
-                "history_current": "19"
+                ]
             }
         },
         {
@@ -96,10 +96,10 @@
                 "supports": [
                     "21"
                 ],
+                "history_current": "20",
                 "history": [
                     "20"
-                ],
-                "history_current": "20"
+                ]
             }
         },
         {
@@ -129,10 +129,10 @@
                     "12",
                     "22"
                 ],
+                "history_current": "21",
                 "history": [
                     "21"
-                ],
-                "history_current": "21"
+                ]
             }
         }
     ],
@@ -145,13 +145,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/version-by-browser-slug-response-body.json
+++ b/docs/v1/raw/version-by-browser-slug-response-body.json
@@ -12,10 +12,10 @@
             "links": {
                 "browser": "7",
                 "supports": [],
+                "history_current": "17",
                 "history": [
                     "17"
-                ],
-                "history_current": "17"
+                ]
             }
         },
         {
@@ -32,10 +32,10 @@
                 "supports": [
                     "4"
                 ],
+                "history_current": "18",
                 "history": [
                     "18"
-                ],
-                "history_current": "18"
+                ]
             }
         },
         {
@@ -64,10 +64,10 @@
                 "supports": [
                     "13"
                 ],
+                "history_current": "19",
                 "history": [
                     "19"
-                ],
-                "history_current": "19"
+                ]
             }
         },
         {
@@ -96,10 +96,10 @@
                 "supports": [
                     "21"
                 ],
+                "history_current": "20",
                 "history": [
                     "20"
-                ],
-                "history_current": "20"
+                ]
             }
         },
         {
@@ -129,10 +129,10 @@
                     "12",
                     "22"
                 ],
+                "history_current": "21",
                 "history": [
                     "21"
-                ],
-                "history_current": "21"
+                ]
             }
         }
     ],
@@ -145,13 +145,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/version-by-id-response-body.json
+++ b/docs/v1/raw/version-by-id-response-body.json
@@ -26,10 +26,10 @@
                 "12",
                 "22"
             ],
+            "history_current": "21",
             "history": [
                 "21"
-            ],
-            "history_current": "21"
+            ]
         }
     },
     "links": {
@@ -41,13 +41,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/version-by-version-1.0-response-body.json
+++ b/docs/v1/raw/version-by-version-1.0-response-body.json
@@ -14,10 +14,10 @@
                 "supports": [
                     "1"
                 ],
+                "history_current": "2",
                 "history": [
                     "2"
-                ],
-                "history_current": "2"
+                ]
             }
         },
         {
@@ -34,10 +34,10 @@
                 "supports": [
                     "2"
                 ],
+                "history_current": "9",
                 "history": [
                     "9"
-                ],
-                "history_current": "9"
+                ]
             }
         },
         {
@@ -52,10 +52,10 @@
             "links": {
                 "browser": "5",
                 "supports": [],
+                "history_current": "12",
                 "history": [
                     "12"
-                ],
-                "history_current": "12"
+                ]
             }
         },
         {
@@ -72,10 +72,10 @@
                 "supports": [
                     "3"
                 ],
+                "history_current": "15",
                 "history": [
                     "15"
-                ],
-                "history_current": "15"
+                ]
             }
         },
         {
@@ -92,10 +92,10 @@
                 "supports": [
                     "4"
                 ],
+                "history_current": "18",
                 "history": [
                     "18"
-                ],
-                "history_current": "18"
+                ]
             }
         },
         {
@@ -110,10 +110,10 @@
             "links": {
                 "browser": "13",
                 "supports": [],
+                "history_current": "39",
                 "history": [
                     "39"
-                ],
-                "history_current": "39"
+                ]
             }
         },
         {
@@ -130,10 +130,10 @@
                 "supports": [
                     "8"
                 ],
+                "history_current": "42",
                 "history": [
                     "42"
-                ],
-                "history_current": "42"
+                ]
             }
         },
         {
@@ -150,10 +150,10 @@
                 "supports": [
                     "10"
                 ],
+                "history_current": "46",
                 "history": [
                     "46"
-                ],
-                "history_current": "46"
+                ]
             }
         }
     ],
@@ -166,13 +166,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/version-by-version-status-response-body.json
+++ b/docs/v1/raw/version-by-version-status-response-body.json
@@ -14,10 +14,10 @@
                 "supports": [
                     "4"
                 ],
+                "history_current": "18",
                 "history": [
                     "18"
-                ],
-                "history_current": "18"
+                ]
             }
         },
         {
@@ -46,10 +46,10 @@
                 "supports": [
                     "13"
                 ],
+                "history_current": "19",
                 "history": [
                     "19"
-                ],
-                "history_current": "19"
+                ]
             }
         },
         {
@@ -78,10 +78,10 @@
                 "supports": [
                     "21"
                 ],
+                "history_current": "20",
                 "history": [
                     "20"
-                ],
-                "history_current": "20"
+                ]
             }
         },
         {
@@ -111,10 +111,10 @@
                     "12",
                     "22"
                 ],
+                "history_current": "21",
                 "history": [
                     "21"
-                ],
-                "history_current": "21"
+                ]
             }
         }
     ],
@@ -127,13 +127,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/version-create-maximized-response-body.json
+++ b/docs/v1/raw/version-create-maximized-response-body.json
@@ -25,10 +25,10 @@
         "links": {
             "browser": "7",
             "supports": [],
+            "history_current": "49",
             "history": [
                 "49"
-            ],
-            "history_current": "49"
+            ]
         }
     },
     "links": {
@@ -40,13 +40,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/version-create-minimal-response-body.json
+++ b/docs/v1/raw/version-create-minimal-response-body.json
@@ -11,10 +11,10 @@
         "links": {
             "browser": "7",
             "supports": [],
+            "history_current": "48",
             "history": [
                 "48"
-            ],
-            "history_current": "48"
+            ]
         }
     },
     "links": {
@@ -26,13 +26,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/version-list-response-body.json
+++ b/docs/v1/raw/version-list-response-body.json
@@ -12,10 +12,10 @@
             "links": {
                 "browser": "1",
                 "supports": [],
+                "history_current": "1",
                 "history": [
                     "1"
-                ],
-                "history_current": "1"
+                ]
             }
         },
         {
@@ -32,10 +32,10 @@
                 "supports": [
                     "1"
                 ],
+                "history_current": "2",
                 "history": [
                     "2"
-                ],
-                "history_current": "2"
+                ]
             }
         },
         {
@@ -50,10 +50,10 @@
             "links": {
                 "browser": "1",
                 "supports": [],
+                "history_current": "3",
                 "history": [
                     "3"
-                ],
-                "history_current": "3"
+                ]
             }
         },
         {
@@ -68,10 +68,10 @@
             "links": {
                 "browser": "2",
                 "supports": [],
+                "history_current": "4",
                 "history": [
                     "4"
-                ],
-                "history_current": "4"
+                ]
             }
         },
         {
@@ -86,10 +86,10 @@
             "links": {
                 "browser": "3",
                 "supports": [],
+                "history_current": "5",
                 "history": [
                     "5"
-                ],
-                "history_current": "5"
+                ]
             }
         },
         {
@@ -104,10 +104,10 @@
             "links": {
                 "browser": "3",
                 "supports": [],
+                "history_current": "6",
                 "history": [
                     "6"
-                ],
-                "history_current": "6"
+                ]
             }
         },
         {
@@ -122,10 +122,10 @@
             "links": {
                 "browser": "3",
                 "supports": [],
+                "history_current": "7",
                 "history": [
                     "7"
-                ],
-                "history_current": "7"
+                ]
             }
         },
         {
@@ -143,10 +143,10 @@
                     "11",
                     "20"
                 ],
+                "history_current": "8",
                 "history": [
                     "8"
-                ],
-                "history_current": "8"
+                ]
             }
         },
         {
@@ -163,10 +163,10 @@
                 "supports": [
                     "2"
                 ],
+                "history_current": "9",
                 "history": [
                     "9"
-                ],
-                "history_current": "9"
+                ]
             }
         },
         {
@@ -181,10 +181,10 @@
             "links": {
                 "browser": "4",
                 "supports": [],
+                "history_current": "10",
                 "history": [
                     "10"
-                ],
-                "history_current": "10"
+                ]
             }
         }
     ],
@@ -197,13 +197,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     },
     "meta": {

--- a/docs/v1/raw/version-revert-response-body.json
+++ b/docs/v1/raw/version-revert-response-body.json
@@ -26,12 +26,12 @@
                 "12",
                 "22"
             ],
+            "history_current": "51",
             "history": [
                 "51",
                 "50",
                 "21"
-            ],
-            "history_current": "51"
+            ]
         }
     },
     "links": {
@@ -43,13 +43,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/version-update-response-body.json
+++ b/docs/v1/raw/version-update-response-body.json
@@ -26,11 +26,11 @@
                 "12",
                 "22"
             ],
+            "history_current": "50",
             "history": [
                 "50",
                 "21"
-            ],
-            "history_current": "50"
+            ]
         }
     },
     "links": {
@@ -42,13 +42,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/version-update-version-change-ignored-response-body.json
+++ b/docs/v1/raw/version-update-version-change-ignored-response-body.json
@@ -26,13 +26,13 @@
                 "12",
                 "22"
             ],
+            "history_current": "54",
             "history": [
                 "54",
                 "51",
                 "50",
                 "21"
-            ],
-            "history_current": "54"
+            ]
         }
     },
     "links": {
@@ -44,13 +44,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/view-feature-by-id-response-body.json
+++ b/docs/v1/raw/view-feature-by-id-response-body.json
@@ -15,16 +15,16 @@
         "obsolete": false,
         "name": "float",
         "links": {
+            "parent": "2",
+            "children": [
+                "6"
+            ],
             "sections": [
                 "1",
                 "2",
                 "3"
             ],
             "supports": [],
-            "parent": "2",
-            "children": [
-                "6"
-            ],
             "history_current": "5",
             "history": [
                 "5"
@@ -32,14 +32,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -47,6 +39,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",
@@ -56,25 +56,25 @@
             "type": "historical_features",
             "href": "https://browsercompat.org/api/v1/historical_features/{features.history}"
         },
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
-        },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
+        },
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         },
         "versions.browser": {
             "type": "browsers",
             "href": "https://browsercompat.org/api/v1/browsers/{versions.browser}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         },
         "supports.version": {
             "type": "versions",
@@ -135,10 +135,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "1",
                     "history": [
                         "1"
-                    ],
-                    "history_current": "1"
+                    ]
                 }
             },
             {
@@ -149,10 +149,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -163,10 +163,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -177,10 +177,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "6",
                     "history": [
                         "6"
-                    ],
-                    "history_current": "6"
+                    ]
                 }
             },
             {
@@ -191,10 +191,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "7",
                     "history": [
                         "7"
-                    ],
-                    "history_current": "7"
+                    ]
                 }
             },
             {
@@ -205,14 +205,14 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "22",
                     "history": [
                         "22",
                         "21",
                         "20",
                         "19",
                         "9"
-                    ],
-                    "history_current": "22"
+                    ]
                 }
             },
             {
@@ -223,10 +223,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "10",
                     "history": [
                         "10"
-                    ],
-                    "history_current": "10"
+                    ]
                 }
             },
             {
@@ -237,10 +237,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "11",
                     "history": [
                         "11"
-                    ],
-                    "history_current": "11"
+                    ]
                 }
             },
             {
@@ -251,10 +251,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "14",
                     "history": [
                         "14"
-                    ],
-                    "history_current": "14"
+                    ]
                 }
             },
             {
@@ -265,10 +265,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             }
         ],
@@ -284,10 +284,10 @@
                 "order": 1,
                 "links": {
                     "browser": "1",
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -301,10 +301,10 @@
                 "order": 0,
                 "links": {
                     "browser": "2",
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -318,10 +318,10 @@
                 "order": 1,
                 "links": {
                     "browser": "4",
+                    "history_current": "9",
                     "history": [
                         "9"
-                    ],
-                    "history_current": "9"
+                    ]
                 }
             },
             {
@@ -335,10 +335,10 @@
                 "order": 1,
                 "links": {
                     "browser": "6",
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             },
             {
@@ -352,10 +352,10 @@
                 "order": 1,
                 "links": {
                     "browser": "7",
+                    "history_current": "18",
                     "history": [
                         "18"
-                    ],
-                    "history_current": "18"
+                    ]
                 }
             },
             {
@@ -369,10 +369,10 @@
                 "order": 1,
                 "links": {
                     "browser": "9",
+                    "history_current": "26",
                     "history": [
                         "26"
-                    ],
-                    "history_current": "26"
+                    ]
                 }
             },
             {
@@ -386,10 +386,10 @@
                 "order": 2,
                 "links": {
                     "browser": "10",
+                    "history_current": "32",
                     "history": [
                         "32"
-                    ],
-                    "history_current": "32"
+                    ]
                 }
             },
             {
@@ -403,10 +403,10 @@
                 "order": 1,
                 "links": {
                     "browser": "11",
+                    "history_current": "34",
                     "history": [
                         "34"
-                    ],
-                    "history_current": "34"
+                    ]
                 }
             },
             {
@@ -420,10 +420,10 @@
                 "order": 1,
                 "links": {
                     "browser": "14",
+                    "history_current": "42",
                     "history": [
                         "42"
-                    ],
-                    "history_current": "42"
+                    ]
                 }
             },
             {
@@ -437,10 +437,10 @@
                 "order": 3,
                 "links": {
                     "browser": "14",
+                    "history_current": "44",
                     "history": [
                         "44"
-                    ],
-                    "history_current": "44"
+                    ]
                 }
             },
             {
@@ -454,10 +454,10 @@
                 "order": 1,
                 "links": {
                     "browser": "15",
+                    "history_current": "46",
                     "history": [
                         "46"
-                    ],
-                    "history_current": "46"
+                    ]
                 }
             }
         ],
@@ -855,6 +855,8 @@
                     "ja": "基本サポート"
                 },
                 "links": {
+                    "parent": "5",
+                    "children": [],
                     "sections": [],
                     "supports": [
                         "1",
@@ -869,8 +871,6 @@
                         "10",
                         "27"
                     ],
-                    "parent": "5",
-                    "children": [],
                     "history_current": "6",
                     "history": [
                         "6"

--- a/docs/v1/raw/view-feature-by-id-with-child-pages-response-body.json
+++ b/docs/v1/raw/view-feature-by-id-with-child-pages-response-body.json
@@ -15,16 +15,16 @@
         "obsolete": false,
         "name": "float",
         "links": {
+            "parent": "2",
+            "children": [
+                "6"
+            ],
             "sections": [
                 "1",
                 "2",
                 "3"
             ],
             "supports": [],
-            "parent": "2",
-            "children": [
-                "6"
-            ],
             "history_current": "5",
             "history": [
                 "5"
@@ -32,14 +32,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -47,6 +39,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",
@@ -56,25 +56,25 @@
             "type": "historical_features",
             "href": "https://browsercompat.org/api/v1/historical_features/{features.history}"
         },
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
-        },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
+        },
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         },
         "versions.browser": {
             "type": "browsers",
             "href": "https://browsercompat.org/api/v1/browsers/{versions.browser}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         },
         "supports.version": {
             "type": "versions",
@@ -135,10 +135,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "1",
                     "history": [
                         "1"
-                    ],
-                    "history_current": "1"
+                    ]
                 }
             },
             {
@@ -149,10 +149,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -163,10 +163,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -177,10 +177,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "6",
                     "history": [
                         "6"
-                    ],
-                    "history_current": "6"
+                    ]
                 }
             },
             {
@@ -191,10 +191,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "7",
                     "history": [
                         "7"
-                    ],
-                    "history_current": "7"
+                    ]
                 }
             },
             {
@@ -205,14 +205,14 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "22",
                     "history": [
                         "22",
                         "21",
                         "20",
                         "19",
                         "9"
-                    ],
-                    "history_current": "22"
+                    ]
                 }
             },
             {
@@ -223,10 +223,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "10",
                     "history": [
                         "10"
-                    ],
-                    "history_current": "10"
+                    ]
                 }
             },
             {
@@ -237,10 +237,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "11",
                     "history": [
                         "11"
-                    ],
-                    "history_current": "11"
+                    ]
                 }
             },
             {
@@ -251,10 +251,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "14",
                     "history": [
                         "14"
-                    ],
-                    "history_current": "14"
+                    ]
                 }
             },
             {
@@ -265,10 +265,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             }
         ],
@@ -284,10 +284,10 @@
                 "order": 1,
                 "links": {
                     "browser": "1",
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -301,10 +301,10 @@
                 "order": 0,
                 "links": {
                     "browser": "2",
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -318,10 +318,10 @@
                 "order": 1,
                 "links": {
                     "browser": "4",
+                    "history_current": "9",
                     "history": [
                         "9"
-                    ],
-                    "history_current": "9"
+                    ]
                 }
             },
             {
@@ -335,10 +335,10 @@
                 "order": 1,
                 "links": {
                     "browser": "6",
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             },
             {
@@ -352,10 +352,10 @@
                 "order": 1,
                 "links": {
                     "browser": "7",
+                    "history_current": "18",
                     "history": [
                         "18"
-                    ],
-                    "history_current": "18"
+                    ]
                 }
             },
             {
@@ -369,10 +369,10 @@
                 "order": 1,
                 "links": {
                     "browser": "9",
+                    "history_current": "26",
                     "history": [
                         "26"
-                    ],
-                    "history_current": "26"
+                    ]
                 }
             },
             {
@@ -386,10 +386,10 @@
                 "order": 2,
                 "links": {
                     "browser": "10",
+                    "history_current": "32",
                     "history": [
                         "32"
-                    ],
-                    "history_current": "32"
+                    ]
                 }
             },
             {
@@ -403,10 +403,10 @@
                 "order": 1,
                 "links": {
                     "browser": "11",
+                    "history_current": "34",
                     "history": [
                         "34"
-                    ],
-                    "history_current": "34"
+                    ]
                 }
             },
             {
@@ -420,10 +420,10 @@
                 "order": 1,
                 "links": {
                     "browser": "14",
+                    "history_current": "42",
                     "history": [
                         "42"
-                    ],
-                    "history_current": "42"
+                    ]
                 }
             },
             {
@@ -437,10 +437,10 @@
                 "order": 3,
                 "links": {
                     "browser": "14",
+                    "history_current": "44",
                     "history": [
                         "44"
-                    ],
-                    "history_current": "44"
+                    ]
                 }
             },
             {
@@ -454,10 +454,10 @@
                 "order": 1,
                 "links": {
                     "browser": "15",
+                    "history_current": "46",
                     "history": [
                         "46"
-                    ],
-                    "history_current": "46"
+                    ]
                 }
             }
         ],
@@ -855,6 +855,8 @@
                     "ja": "基本サポート"
                 },
                 "links": {
+                    "parent": "5",
+                    "children": [],
                     "sections": [],
                     "supports": [
                         "1",
@@ -869,8 +871,6 @@
                         "10",
                         "27"
                     ],
-                    "parent": "5",
-                    "children": [],
                     "history_current": "6",
                     "history": [
                         "6"

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-2-response-body.json
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-2-response-body.json
@@ -11,10 +11,10 @@
         "links": {
             "browser": "3",
             "supports": [],
+            "history_current": "53",
             "history": [
                 "53"
-            ],
-            "history_current": "53"
+            ]
         }
     },
     "links": {
@@ -26,13 +26,13 @@
             "type": "supports",
             "href": "https://browsercompat.org/api/v1/supports/{versions.supports}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         }
     }
 }

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-5-response-body.json
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-5-response-body.json
@@ -15,16 +15,16 @@
         "obsolete": false,
         "name": "float",
         "links": {
+            "parent": "2",
+            "children": [
+                "6"
+            ],
             "sections": [
                 "1",
                 "2",
                 "3"
             ],
             "supports": [],
-            "parent": "2",
-            "children": [
-                "6"
-            ],
             "history_current": "5",
             "history": [
                 "5"
@@ -32,14 +32,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -47,6 +39,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",
@@ -56,25 +56,25 @@
             "type": "historical_features",
             "href": "https://browsercompat.org/api/v1/historical_features/{features.history}"
         },
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
-        },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
+        },
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         },
         "versions.browser": {
             "type": "browsers",
             "href": "https://browsercompat.org/api/v1/browsers/{versions.browser}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         },
         "supports.version": {
             "type": "versions",
@@ -135,10 +135,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "1",
                     "history": [
                         "1"
-                    ],
-                    "history_current": "1"
+                    ]
                 }
             },
             {
@@ -149,10 +149,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -163,10 +163,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "3",
                     "history": [
                         "3"
-                    ],
-                    "history_current": "3"
+                    ]
                 }
             },
             {
@@ -177,10 +177,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -191,10 +191,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "6",
                     "history": [
                         "6"
-                    ],
-                    "history_current": "6"
+                    ]
                 }
             },
             {
@@ -205,10 +205,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "7",
                     "history": [
                         "7"
-                    ],
-                    "history_current": "7"
+                    ]
                 }
             },
             {
@@ -219,14 +219,14 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "22",
                     "history": [
                         "22",
                         "21",
                         "20",
                         "19",
                         "9"
-                    ],
-                    "history_current": "22"
+                    ]
                 }
             },
             {
@@ -237,10 +237,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "10",
                     "history": [
                         "10"
-                    ],
-                    "history_current": "10"
+                    ]
                 }
             },
             {
@@ -251,10 +251,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "11",
                     "history": [
                         "11"
-                    ],
-                    "history_current": "11"
+                    ]
                 }
             },
             {
@@ -265,10 +265,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "14",
                     "history": [
                         "14"
-                    ],
-                    "history_current": "14"
+                    ]
                 }
             },
             {
@@ -279,10 +279,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             }
         ],
@@ -298,10 +298,10 @@
                 "order": 1,
                 "links": {
                     "browser": "1",
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -315,10 +315,10 @@
                 "order": 0,
                 "links": {
                     "browser": "2",
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -332,10 +332,10 @@
                 "order": 1,
                 "links": {
                     "browser": "4",
+                    "history_current": "9",
                     "history": [
                         "9"
-                    ],
-                    "history_current": "9"
+                    ]
                 }
             },
             {
@@ -349,10 +349,10 @@
                 "order": 1,
                 "links": {
                     "browser": "6",
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             },
             {
@@ -366,10 +366,10 @@
                 "order": 1,
                 "links": {
                     "browser": "7",
+                    "history_current": "18",
                     "history": [
                         "18"
-                    ],
-                    "history_current": "18"
+                    ]
                 }
             },
             {
@@ -383,10 +383,10 @@
                 "order": 1,
                 "links": {
                     "browser": "9",
+                    "history_current": "26",
                     "history": [
                         "26"
-                    ],
-                    "history_current": "26"
+                    ]
                 }
             },
             {
@@ -400,10 +400,10 @@
                 "order": 2,
                 "links": {
                     "browser": "10",
+                    "history_current": "32",
                     "history": [
                         "32"
-                    ],
-                    "history_current": "32"
+                    ]
                 }
             },
             {
@@ -417,10 +417,10 @@
                 "order": 1,
                 "links": {
                     "browser": "11",
+                    "history_current": "34",
                     "history": [
                         "34"
-                    ],
-                    "history_current": "34"
+                    ]
                 }
             },
             {
@@ -434,10 +434,10 @@
                 "order": 1,
                 "links": {
                     "browser": "14",
+                    "history_current": "42",
                     "history": [
                         "42"
-                    ],
-                    "history_current": "42"
+                    ]
                 }
             },
             {
@@ -451,10 +451,10 @@
                 "order": 3,
                 "links": {
                     "browser": "14",
+                    "history_current": "44",
                     "history": [
                         "44"
-                    ],
-                    "history_current": "44"
+                    ]
                 }
             },
             {
@@ -468,10 +468,10 @@
                 "order": 1,
                 "links": {
                     "browser": "15",
+                    "history_current": "46",
                     "history": [
                         "46"
-                    ],
-                    "history_current": "46"
+                    ]
                 }
             },
             {
@@ -485,10 +485,10 @@
                 "order": 3,
                 "links": {
                     "browser": "3",
+                    "history_current": "53",
                     "history": [
                         "53"
-                    ],
-                    "history_current": "53"
+                    ]
                 }
             }
         ],
@@ -906,6 +906,8 @@
                     "ja": "基本サポート"
                 },
                 "links": {
+                    "parent": "5",
+                    "children": [],
                     "sections": [],
                     "supports": [
                         "1",
@@ -921,8 +923,6 @@
                         "27",
                         "29"
                     ],
-                    "parent": "5",
-                    "children": [],
                     "history_current": "6",
                     "history": [
                         "6"

--- a/docs/v1/raw/view-feature-update-put-subfeature-response-body.json
+++ b/docs/v1/raw/view-feature-update-put-subfeature-response-body.json
@@ -15,17 +15,17 @@
         "obsolete": false,
         "name": "float",
         "links": {
+            "parent": "2",
+            "children": [
+                "6",
+                "19"
+            ],
             "sections": [
                 "1",
                 "2",
                 "3"
             ],
             "supports": [],
-            "parent": "2",
-            "children": [
-                "6",
-                "19"
-            ],
             "history_current": "25",
             "history": [
                 "25",
@@ -34,14 +34,6 @@
         }
     },
     "links": {
-        "features.sections": {
-            "type": "sections",
-            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
-        },
-        "features.supports": {
-            "type": "supports",
-            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
-        },
         "features.parent": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.parent}"
@@ -49,6 +41,14 @@
         "features.children": {
             "type": "features",
             "href": "https://browsercompat.org/api/v1/features/{features.children}"
+        },
+        "features.sections": {
+            "type": "sections",
+            "href": "https://browsercompat.org/api/v1/sections/{features.sections}"
+        },
+        "features.supports": {
+            "type": "supports",
+            "href": "https://browsercompat.org/api/v1/supports/{features.supports}"
         },
         "features.history_current": {
             "type": "historical_features",
@@ -58,25 +58,25 @@
             "type": "historical_features",
             "href": "https://browsercompat.org/api/v1/historical_features/{features.history}"
         },
-        "browsers.history": {
-            "type": "historical_browsers",
-            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
-        },
         "browsers.history_current": {
             "type": "historical_browsers",
             "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history_current}"
+        },
+        "browsers.history": {
+            "type": "historical_browsers",
+            "href": "https://browsercompat.org/api/v1/historical_browsers/{browsers.history}"
         },
         "versions.browser": {
             "type": "browsers",
             "href": "https://browsercompat.org/api/v1/browsers/{versions.browser}"
         },
-        "versions.history": {
-            "type": "historical_versions",
-            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
-        },
         "versions.history_current": {
             "type": "historical_versions",
             "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history_current}"
+        },
+        "versions.history": {
+            "type": "historical_versions",
+            "href": "https://browsercompat.org/api/v1/historical_versions/{versions.history}"
         },
         "supports.version": {
             "type": "versions",
@@ -137,10 +137,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "1",
                     "history": [
                         "1"
-                    ],
-                    "history_current": "1"
+                    ]
                 }
             },
             {
@@ -151,10 +151,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -165,10 +165,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "3",
                     "history": [
                         "3"
-                    ],
-                    "history_current": "3"
+                    ]
                 }
             },
             {
@@ -179,10 +179,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -193,10 +193,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "6",
                     "history": [
                         "6"
-                    ],
-                    "history_current": "6"
+                    ]
                 }
             },
             {
@@ -207,10 +207,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "7",
                     "history": [
                         "7"
-                    ],
-                    "history_current": "7"
+                    ]
                 }
             },
             {
@@ -221,14 +221,14 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "22",
                     "history": [
                         "22",
                         "21",
                         "20",
                         "19",
                         "9"
-                    ],
-                    "history_current": "22"
+                    ]
                 }
             },
             {
@@ -239,10 +239,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "10",
                     "history": [
                         "10"
-                    ],
-                    "history_current": "10"
+                    ]
                 }
             },
             {
@@ -253,10 +253,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "11",
                     "history": [
                         "11"
-                    ],
-                    "history_current": "11"
+                    ]
                 }
             },
             {
@@ -267,10 +267,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "14",
                     "history": [
                         "14"
-                    ],
-                    "history_current": "14"
+                    ]
                 }
             },
             {
@@ -281,10 +281,10 @@
                 },
                 "note": null,
                 "links": {
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             }
         ],
@@ -300,10 +300,10 @@
                 "order": 1,
                 "links": {
                     "browser": "1",
+                    "history_current": "2",
                     "history": [
                         "2"
-                    ],
-                    "history_current": "2"
+                    ]
                 }
             },
             {
@@ -317,10 +317,10 @@
                 "order": 0,
                 "links": {
                     "browser": "2",
+                    "history_current": "4",
                     "history": [
                         "4"
-                    ],
-                    "history_current": "4"
+                    ]
                 }
             },
             {
@@ -334,10 +334,10 @@
                 "order": 1,
                 "links": {
                     "browser": "4",
+                    "history_current": "9",
                     "history": [
                         "9"
-                    ],
-                    "history_current": "9"
+                    ]
                 }
             },
             {
@@ -351,10 +351,10 @@
                 "order": 1,
                 "links": {
                     "browser": "6",
+                    "history_current": "15",
                     "history": [
                         "15"
-                    ],
-                    "history_current": "15"
+                    ]
                 }
             },
             {
@@ -368,10 +368,10 @@
                 "order": 1,
                 "links": {
                     "browser": "7",
+                    "history_current": "18",
                     "history": [
                         "18"
-                    ],
-                    "history_current": "18"
+                    ]
                 }
             },
             {
@@ -385,10 +385,10 @@
                 "order": 1,
                 "links": {
                     "browser": "9",
+                    "history_current": "26",
                     "history": [
                         "26"
-                    ],
-                    "history_current": "26"
+                    ]
                 }
             },
             {
@@ -402,10 +402,10 @@
                 "order": 2,
                 "links": {
                     "browser": "10",
+                    "history_current": "32",
                     "history": [
                         "32"
-                    ],
-                    "history_current": "32"
+                    ]
                 }
             },
             {
@@ -419,10 +419,10 @@
                 "order": 1,
                 "links": {
                     "browser": "11",
+                    "history_current": "34",
                     "history": [
                         "34"
-                    ],
-                    "history_current": "34"
+                    ]
                 }
             },
             {
@@ -436,10 +436,10 @@
                 "order": 1,
                 "links": {
                     "browser": "14",
+                    "history_current": "42",
                     "history": [
                         "42"
-                    ],
-                    "history_current": "42"
+                    ]
                 }
             },
             {
@@ -453,10 +453,10 @@
                 "order": 3,
                 "links": {
                     "browser": "14",
+                    "history_current": "44",
                     "history": [
                         "44"
-                    ],
-                    "history_current": "44"
+                    ]
                 }
             },
             {
@@ -470,10 +470,10 @@
                 "order": 1,
                 "links": {
                     "browser": "15",
+                    "history_current": "46",
                     "history": [
                         "46"
-                    ],
-                    "history_current": "46"
+                    ]
                 }
             },
             {
@@ -487,10 +487,10 @@
                 "order": 3,
                 "links": {
                     "browser": "3",
+                    "history_current": "53",
                     "history": [
                         "53"
-                    ],
-                    "history_current": "53"
+                    ]
                 }
             }
         ],
@@ -908,6 +908,8 @@
                     "ja": "基本サポート"
                 },
                 "links": {
+                    "parent": "5",
+                    "children": [],
                     "sections": [],
                     "supports": [
                         "1",
@@ -923,8 +925,6 @@
                         "27",
                         "29"
                     ],
-                    "parent": "5",
-                    "children": [],
                     "history_current": "6",
                     "history": [
                         "6"
@@ -943,10 +943,10 @@
                     "en": "New Subfeature"
                 },
                 "links": {
-                    "sections": [],
-                    "supports": [],
                     "parent": "5",
                     "children": [],
+                    "sections": [],
+                    "supports": [],
                     "history_current": "26",
                     "history": [
                         "26"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,6 @@ django-filter==0.11.0
 six==1.10.0
 django-extensions==1.5.9
 
-# JSON API interfaces for Django REST Framework
-git+git://github.com/jwhitlock/drf-json-api@v0.1d#egg=drf-json-api
-
 # History of changes to models
 django-simple-history==1.6.3
 

--- a/tools/integration_requests.py
+++ b/tools/integration_requests.py
@@ -30,7 +30,8 @@ class CaseRunner(object):
         'GET': 200,
         'POST': 201,
         'PUT': 200,
-        'DELETE': 204
+        'DELETE': 204,
+        'OPTIONS': 200,
     }
     doc_csrf = "p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn"
     doc_session = "wurexa2wq416ftlvd5plesngwa28183h"

--- a/webplatformcompat/__init__.py
+++ b/webplatformcompat/__init__.py
@@ -1,1 +1,2 @@
+"""The BrowserCompat API app."""
 __version__ = '0.1.0'

--- a/webplatformcompat/drf_fields.py
+++ b/webplatformcompat/drf_fields.py
@@ -22,7 +22,7 @@ class CurrentHistoryField(PrimaryKeyRelatedField):
 
     def __init__(self, *args, **kwargs):
         self.manager = kwargs.pop('manager', 'history')
-        read_only = kwargs.pop('read_only', None)
+        read_only = kwargs.pop('read_only', False)
         queryset = None if read_only else 'to do'
         required = kwargs.pop('required', False)
         assert not required, 'required must be False'

--- a/webplatformcompat/jinja2/rest_framework/api.html
+++ b/webplatformcompat/jinja2/rest_framework/api.html
@@ -50,17 +50,13 @@
         {% endif %}
 
         {% if options_form %}
-            <form class="button-form" action="{{ request.get_full_path() }}" method="POST" class="pull-right">
-                {{ csrf_input }}
-                <input type="hidden" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="OPTIONS" />
+            <form class="button-form" action="{{ request.get_full_path() }}" data-method="OPTIONS" class="pull-right">
                 <button class="btn btn-primary js-tooltip" title="Make an OPTIONS request on the {{ name }} resource">OPTIONS</button>
             </form>
         {% endif %}
 
         {% if delete_form %}
-            <form class="button-form" action="{{ request.get_full_path() }}" method="POST" class="pull-right">
-                {{ csrf_input }}
-                <input type="hidden" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="DELETE" />
+            <form class="button-form" action="{{ request.get_full_path() }}" data-method="DELETE" class="pull-right">
                 <button class="btn btn-danger js-tooltip" title="Make a DELETE request on the {{ name }} resource">DELETE</button>
             </form>
         {% endif %}
@@ -172,8 +168,15 @@
 {% endblock content %}
 
 {% block body_js_extra %}
+    <script src="{{ static("rest_framework/js/ajax-form.js") }}"></script>
+    <script src="{{ static("rest_framework/js/csrf.js") }}"></script>
     <script src="{{ static("rest_framework/js/prettify-min.js") }}"></script>
     <script src="{{ static("rest_framework/js/default.js") }}"></script>
+    <script>
+        $(document).ready(function() {
+            $('form').ajaxForm();
+        });
+    </script>
 {% endblock body_js_extra %}
 
 {% block footer %}

--- a/webplatformcompat/jinja2/webplatformcompat/feature-basic.html
+++ b/webplatformcompat/jinja2/webplatformcompat/feature-basic.html
@@ -119,7 +119,7 @@
           {%- endif %}
         {%- else %}
 
-        ({{ support.support}})
+        (unknown)
         {%- endfor %}
 
       </td>

--- a/webplatformcompat/parsers.py
+++ b/webplatformcompat/parsers.py
@@ -1,49 +1,67 @@
-from rest_framework_json_api.parsers import JsonApiParser \
-    as BaseJsonApiParser
-from rest_framework_json_api.parsers import JsonApiMixin
-from rest_framework_json_api.utils import snakecase
+# -*- coding: utf-8 -*-
+"""Parser for JSON API RC1."""
+
+from collections import OrderedDict
+
+from rest_framework.exceptions import ParseError
+from rest_framework.parsers import JSONParser
 
 
-class JsonApiParser(BaseJsonApiParser):
-    def model_to_resource_type(self, model):
-        if model:
-            return snakecase(model._meta.verbose_name_plural)
-        else:
-            return 'data'
+class JsonApiRC1Parser(JSONParser):
+    media_type = 'application/vnd.api+json'
+    dict_class = OrderedDict
 
     def parse(self, stream, media_type=None, parser_context=None):
-        """Parse JSON API representation into DRF native format.
+        """Parse JSON API representation into DRF native format."""
+        data = super(JsonApiRC1Parser, self).parse(
+            stream, media_type=media_type, parser_context=parser_context)
 
-        Same as rest_framework_json_api.parsers.JsonApiMixin.parse,
-        except that linked and meta sections are put into _view_extra
-        """
-        data = super(JsonApiMixin, self).parse(stream, media_type=media_type,
-                                               parser_context=parser_context)
+        view = parser_context['view']
+        model = view.queryset.model
+        resource_type = model._meta.verbose_name_plural
 
-        view = parser_context.get("view", None)
-
-        model = self.model_from_obj(view)
-        resource_type = self.model_to_resource_type(model)
-
-        resource = {}
-
-        if resource_type in data:
-            resource = data[resource_type]
-
-        if isinstance(resource, list):  # pragma: nocover
-            resource = [self.convert_resource(r, view) for r in resource]
-        else:
-            resource = self.convert_resource(resource, view)
-
-        # Add extra data to _view_extra
-        # This should mirror .renderers.JsonApiRenderer.wrap_view_extra
-        view_extra = {}
-        if 'meta' in data:
-            view_extra['meta'] = data['meta']
-        if 'linked' in data:
-            assert 'meta' not in data['linked']
-            view_extra.update(data['linked'])
+        resource = self.dict_class()
+        view_extra = self.dict_class()
+        for name, value in data.items():
+            if name == resource_type:
+                resource = self.convert(value)
+            elif name == 'linked':
+                for linked_name, linked_values in value.items():
+                    if linked_name == 'meta':
+                        raise ParseError('"meta" not allowed in linked.')
+                    view_extra[linked_name] = self.convert(linked_values)
+            elif name == 'meta':
+                view_extra['meta'] = value
+            # JSON API requires ignoring additional attributes
         if view_extra:
             resource['_view_extra'] = view_extra
+        return resource
 
+    def convert(self, raw_data):
+        if isinstance(raw_data, list):
+            return [self.convert_item(item) for item in raw_data]
+        else:
+            return self.convert_item(raw_data)
+
+    def convert_item(self, raw_data):
+        resource = self.dict_class()
+        for name, value in raw_data.items():
+            if name == 'links':
+                for link_name, link_value in value.items():
+                    if link_name in resource:
+                        raise ParseError(
+                            'Attribute "%s" duplicated in links.' % link_name)
+                    elif link_name == '_view_extra':
+                        raise ParseError(
+                            '"_view_extra" not allowed as link name.')
+                    assert link_name not in resource
+                    resource[link_name] = link_value
+            elif name == '_view_extra':
+                raise ParseError(
+                    '"_view_extra" not allowed as attribute name.')
+            else:
+                if name in resource:
+                    raise ParseError(
+                        'Link %s duplicated in attributes.' % name)
+                resource[name] = value
         return resource

--- a/webplatformcompat/parsers.py
+++ b/webplatformcompat/parsers.py
@@ -54,7 +54,6 @@ class JsonApiRC1Parser(JSONParser):
                     elif link_name == '_view_extra':
                         raise ParseError(
                             '"_view_extra" not allowed as link name.')
-                    assert link_name not in resource
                     resource[link_name] = link_value
             elif name == '_view_extra':
                 raise ParseError(

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -31,8 +31,8 @@ class JsonApiRC1Renderer(JSONRenderer):
         - Standard data (with serializer and fields_extra)
         - Paginated data
         """
-        response = renderer_context.get('response')
-        request = renderer_context.get('request')
+        response = renderer_context['response']
+        request = renderer_context['request']
         fields_extra = renderer_context.get('fields_extra')
         status_code = response and response.status_code
         is_err = is_client_error(status_code) or is_server_error(status_code)

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -42,6 +42,8 @@ class JsonApiRC1Renderer(JSONRenderer):
             converted = self.convert_error(data, status_code)
         elif all([key in data for key in self.PAGINATION_KEYS]):
             converted = self.convert_paginated(data, request)
+        elif request and request.method == 'OPTIONS':
+            converted = {'meta': data}
         else:
             main_resource = fields_extra['id']['resource']
             converted = self.convert_standard(

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -10,6 +10,7 @@ from django.utils import translation
 
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.renderers import BrowsableAPIRenderer as BaseAPIRenderer
+from rest_framework.utils.serializer_helpers import ReturnList
 from rest_framework.status import (
     HTTP_200_OK, HTTP_204_NO_CONTENT, is_client_error, is_server_error)
 from rest_framework.utils.encoders import JSONEncoder
@@ -185,7 +186,9 @@ class JsonApiRC1Renderer(JSONRenderer):
         ReturnList's attached ListSerializer, and using the request to build
         full URLs.
         """
-        assert hasattr(return_list, 'serializer'), "Must be ReturnList"
+        assert isinstance(return_list, ReturnList), (
+            "Should be ReturnList (for serializer data), is %s" %
+            type(return_list))
         serializer = return_list.serializer.child
         fields_extra = serializer.get_fields_extra()
         main_resource = fields_extra['id']['resource']

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -217,11 +217,11 @@ class JsonApiRC1Renderer(JSONRenderer):
         link = field_extra['link']
         if value is None:
             link_id = None
-        elif link in ('from_many', 'to_many'):
+        elif link == 'from_many':
             link_id = [str(pk) for pk in value]
-        elif link == 'self':
-            link_id = str(value)
         else:
+            assert link in ('self', 'from_one', 'to_one'), (
+                '"%s" is an unexpected link type' % link)
             link_id = str(value)
 
         pattern = None

--- a/webplatformcompat/routers.py
+++ b/webplatformcompat/routers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""URL router for API endpoints."""
 
 from collections import OrderedDict
 

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -146,8 +146,8 @@ class BrowserSerializer(HistoricalModelSerializer):
     class Meta:
         model = Browser
         fields = (
-            'id', 'slug', 'name', 'note', 'history', 'history_current',
-            'versions')
+            'id', 'slug', 'name', 'note', 'versions', 'history_current',
+            'history')
         fields_extra = {
             'id': {
                 'link': 'self',
@@ -155,18 +155,18 @@ class BrowserSerializer(HistoricalModelSerializer):
             'slug': {
                 'writable': 'create_only',
             },
-            'history': {
-                'archive': 'omit',
+            'versions': {
                 'link': 'from_many',
+                'writable': 'update_only',
             },
             'history_current': {
                 'archive': 'history_id',
                 'link': 'from_one',
                 'writable': 'update_only',
             },
-            'versions': {
+            'history': {
+                'archive': 'omit',
                 'link': 'from_many',
-                'writable': 'update_only',
             },
         }
 
@@ -212,20 +212,12 @@ class FeatureSerializer(HistoricalModelSerializer):
         model = Feature
         fields = (
             'id', 'slug', 'mdn_uri', 'experimental', 'standardized',
-            'stable', 'obsolete', 'name',
-            'sections', 'supports', 'parent', 'children',
-            'history_current', 'history')
+            'stable', 'obsolete', 'name', 'parent', 'children',
+            'sections', 'supports', 'history_current', 'history')
         read_only_fields = ('supports',)
         fields_extra = {
             'id': {
                 'link': 'self',
-            },
-            'sections': {
-                'link': 'from_many',
-            },
-            'supports': {
-                'archive': 'omit',
-                'link': 'from_many',
             },
             'parent': {
                 'link': 'to_one',
@@ -233,6 +225,13 @@ class FeatureSerializer(HistoricalModelSerializer):
             'children': {
                 'link': 'from_many',
                 'writable': 'update_only'
+            },
+            'sections': {
+                'link': 'from_many',
+            },
+            'supports': {
+                'archive': 'omit',
+                'link': 'from_many',
             },
             'history_current': {
                 'archive': 'history_id',
@@ -365,10 +364,10 @@ class SupportSerializer(HistoricalModelSerializer):
     class Meta:
         model = Support
         fields = (
-            'id', 'version', 'feature', 'support', 'prefix',
+            'id', 'support', 'prefix',
             'prefix_mandatory', 'alternate_name', 'alternate_mandatory',
             'requires_config', 'default_config', 'protected', 'note',
-            'history_current', 'history')
+            'version', 'feature', 'history_current', 'history')
         fields_extra = {
             'id': {
                 'link': 'self',
@@ -399,9 +398,9 @@ class VersionSerializer(HistoricalModelSerializer):
     class Meta:
         model = Version
         fields = (
-            'id', 'browser', 'version', 'release_day', 'retirement_day',
-            'status', 'release_notes_uri', 'note', 'order',
-            'supports', 'history', 'history_current')
+            'id', 'version', 'release_day', 'retirement_day',
+            'status', 'release_notes_uri', 'note', 'order', 'browser',
+            'supports', 'history_current', 'history')
         extra_kwargs = {
             'version': {
                 'allow_blank': False
@@ -413,11 +412,11 @@ class VersionSerializer(HistoricalModelSerializer):
             'id': {
                 'link': 'self',
             },
-            'browser': {
-                'link': 'to_one',
-            },
             'version': {
                 'writable': 'create_only',
+            },
+            'browser': {
+                'link': 'to_one',
             },
             'supports': {
                 'archive': 'omit',
@@ -627,10 +626,7 @@ class HistoricalObjectSerializer(ModelSerializer):
 class HistoricalBrowserSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, BrowserSerializer):
-        class Meta(BrowserSerializer.Meta):
-            fields = (
-                'id', 'slug', 'name', 'note', 'versions', 'history',
-                'history_current')
+        pass
 
     browser = HistoricalObjectField()
     browsers = SerializerMethodField('get_archive')
@@ -644,12 +640,7 @@ class HistoricalBrowserSerializer(HistoricalObjectSerializer):
 class HistoricalFeatureSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, FeatureSerializer):
-        class Meta(FeatureSerializer.Meta):
-            fields = (
-                'id', 'slug', 'mdn_uri', 'experimental', 'standardized',
-                'stable', 'obsolete', 'name',
-                'supports', 'parent', 'children', 'sections',
-                'history_current', 'history')
+        pass
 
     feature = HistoricalObjectField()
     features = SerializerMethodField('get_archive')
@@ -663,8 +654,7 @@ class HistoricalFeatureSerializer(HistoricalObjectSerializer):
 class HistoricalMaturitySerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, MaturitySerializer):
-        class Meta(MaturitySerializer.Meta):
-            pass
+        pass
 
     maturity = HistoricalObjectField()
     maturities = SerializerMethodField('get_archive')

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -46,7 +46,10 @@ class WriteRestrictedMixin(object):
                 field_extra = fields_extra.get(field_name, {})
                 writable = field_extra.get('writable', True)
                 if writable == set_to_readonly:
-                    assert not field.read_only
+                    assert not field.read_only, (
+                        ('%s was requested to be set read-only for %s,'
+                         ' but is already read-only by default.')
+                        % (field_name, view and view.action or 'unknown'))
                     field.read_only = True
 
         return fields
@@ -93,7 +96,9 @@ class HistoricalModelSerializer(
 
         The history field is a list of PKs for all the history records.
         """
-        assert field_name == 'history'
+        assert field_name == 'history', (
+            'Expected field name to be "history", got "%s"'
+            % field_name)
         field_kwargs = {'many': True, 'read_only': True}
         return HistoryField, field_kwargs
 
@@ -103,7 +108,10 @@ class HistoricalModelSerializer(
         history_current returns the PK of the most recent history record.
         It is treated as read-only unless it is an update view.
         """
-        assert field_name == 'history_current'
+        assert field_name == 'history_current', (
+            'Expected field name to be "history_current", got "%s"'
+            % field_name)
+
         return CurrentHistoryField, {}
 
     def to_internal_value(self, data):
@@ -667,7 +675,9 @@ class HistoricalObjectSerializer(ModelSerializer):
             elif archive == 'history_id':
                 links[name] = str(obj.history_id)
             else:
-                assert archive == 'omit'
+                assert archive == 'omit', (
+                    'Unknown value "%s" for fields_extra["%s"]["archive"]'
+                    % (archive, name))
         data['links'] = links
         return data
 

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -20,13 +20,6 @@ from .models import (
 from .validators import VersionAndStatusValidator
 
 
-def omit_some(source_list, *omitted):
-    """Return a list with some items omitted"""
-    for item in omitted:
-        assert item in source_list, '%r not in %r' % (item, source_list)
-    return [x for x in source_list if x not in omitted]
-
-
 #
 # "Regular" Serializers
 #

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -149,15 +149,25 @@ class BrowserSerializer(HistoricalModelSerializer):
             'id', 'slug', 'name', 'note', 'history', 'history_current',
             'versions')
         fields_extra = {
+            'id': {
+                'link': 'self',
+            },
             'slug': {
                 'writable': 'create_only',
             },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
             'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
                 'writable': 'update_only',
             },
             'versions': {
+                'link': 'from_many',
                 'writable': 'update_only',
-            }
+            },
         }
 
 
@@ -206,6 +216,34 @@ class FeatureSerializer(HistoricalModelSerializer):
             'sections', 'supports', 'parent', 'children',
             'history_current', 'history')
         read_only_fields = ('supports',)
+        fields_extra = {
+            'id': {
+                'link': 'self',
+            },
+            'sections': {
+                'link': 'from_many',
+            },
+            'supports': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+            'parent': {
+                'link': 'to_one',
+            },
+            'children': {
+                'link': 'from_many',
+                'writable': 'update_only'
+            },
+            'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
+                'writable': 'update_only',
+            },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+        }
 
 
 class MaturitySerializer(HistoricalModelSerializer):
@@ -217,6 +255,24 @@ class MaturitySerializer(HistoricalModelSerializer):
             'id', 'slug', 'name', 'specifications',
             'history_current', 'history')
         read_only_fields = ('specifications',)
+        fields_extra = {
+            'id': {
+                'link': 'self',
+            },
+            'specifications': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+            'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
+                'writable': 'update_only',
+            },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+        }
 
 
 class SectionSerializer(HistoricalModelSerializer):
@@ -231,6 +287,27 @@ class SectionSerializer(HistoricalModelSerializer):
             'features': {
                 'default': []
             }
+        }
+        fields_extra = {
+            'id': {
+                'link': 'self',
+            },
+            'specification': {
+                'link': 'to_one',
+            },
+            'features': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+            'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
+                'writable': 'update_only',
+            },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
         }
 
 
@@ -260,6 +337,26 @@ class SpecificationSerializer(HistoricalModelSerializer):
                 'default': []
             }
         }
+        fields_extra = {
+            'id': {
+                'link': 'self',
+            },
+            'maturity': {
+                'link': 'to_one',
+            },
+            'sections': {
+                'link': 'from_many',
+            },
+            'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
+                'writable': 'update_only',
+            },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+        }
 
 
 class SupportSerializer(HistoricalModelSerializer):
@@ -272,6 +369,26 @@ class SupportSerializer(HistoricalModelSerializer):
             'prefix_mandatory', 'alternate_name', 'alternate_mandatory',
             'requires_config', 'default_config', 'protected', 'note',
             'history_current', 'history')
+        fields_extra = {
+            'id': {
+                'link': 'self',
+            },
+            'version': {
+                'link': 'to_one',
+            },
+            'feature': {
+                'link': 'to_one',
+            },
+            'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
+                'writable': 'update_only',
+            },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+        }
 
 
 class VersionSerializer(HistoricalModelSerializer):
@@ -293,9 +410,28 @@ class VersionSerializer(HistoricalModelSerializer):
         read_only_fields = ('supports',)
         validators = [VersionAndStatusValidator()]
         fields_extra = {
-            "version": {
-                "writable": "create_only",
-            }
+            'id': {
+                'link': 'self',
+            },
+            'browser': {
+                'link': 'to_one',
+            },
+            'version': {
+                'writable': 'create_only',
+            },
+            'supports': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
+            'history_current': {
+                'archive': 'history_id',
+                'link': 'from_one',
+                'writable': 'update_only',
+            },
+            'history': {
+                'archive': 'omit',
+                'link': 'from_many',
+            },
         }
 
 
@@ -330,15 +466,40 @@ class ChangesetSerializer(ModelSerializer):
             }
         }
         fields_extra = {
-            "user": {
-                "writable": "update_only",
+            'id': {
+                'link': 'self',
             },
-            "target_resource_type": {
-                "writable": "update_only",
+            'user': {
+                'link': 'to_one',
+                'writable': 'update_only',
             },
-            "target_resource_id": {
-                "writable": "update_only",
-            }
+            'target_resource_type': {
+                'writable': 'update_only',
+            },
+            'target_resource_id': {
+                'writable': 'update_only',
+            },
+            'historical_browsers': {
+                'link': 'from_many',
+            },
+            'historical_features': {
+                'link': 'from_many',
+            },
+            'historical_maturities': {
+                'link': 'from_many',
+            },
+            'historical_specifications': {
+                'link': 'from_many',
+            },
+            'historical_sections': {
+                'link': 'from_many',
+            },
+            'historical_supports': {
+                'link': 'from_many',
+            },
+            'historical_versions': {
+                'link': 'from_many',
+            },
         }
 
 
@@ -371,6 +532,14 @@ class UserSerializer(ModelSerializer):
             'id', 'username', 'created', 'agreement', 'permissions',
             'changesets')
         read_only_fields = ('username', 'changesets')
+        fields_extra = {
+            'id': {
+                'link': 'self',
+            },
+            'changesets': {
+                'link': 'from_many',
+            },
+        }
 
 
 #
@@ -380,14 +549,22 @@ class UserSerializer(ModelSerializer):
 
 class ArchiveMixin(object):
     def get_fields(self):
-        """Historical models don't quite follow Django model conventions."""
+        """Modify fields when loading or preparing an archive."""
         fields = super(ArchiveMixin, self).get_fields()
-
-        # Archived link fields are to-one relations
-        for link_field in getattr(self.Meta, 'archive_link_fields', []):
-            field = fields[link_field]
-            field.source = (field.source or link_field) + '_id'
-
+        fields_extra = getattr(self.Meta, 'fields_extra', {})
+        for field_name, field in fields.items():
+            field_extra = fields_extra.get(field_name, {})
+            archive = field_extra.get('archive')
+            link = field_extra.get('link')
+            if archive == 'omit':
+                # Does not appear in archived representation
+                del fields[field_name]
+            elif link in ('from_one', 'from_many'):
+                # Defer loading until HistoricalObjectSerializer.get_archive
+                del fields[field_name]
+            elif link == 'to_one':
+                # Use the name_id field
+                field.source = field_name + '_id'
         return fields
 
 
@@ -411,26 +588,36 @@ class HistoricalObjectSerializer(ModelSerializer):
 
     def get_archive(self, obj):
         serializer = self.ArchivedObject(obj)
-        data = serializer.data
-        data['id'] = str(data['id'])
-        data['links'] = OrderedDict()
-
-        # Archived link fields are to-one relations
-        for field in getattr(serializer.Meta, 'archive_link_fields', []):
-            del data[field]
-            value = getattr(obj, field + '_id')
-            if value is not None:
-                value = str(value)
-            data['links'][field] = value
-
-        # Archived cached links fields are a list of primary keys
-        for field in getattr(
-                serializer.Meta, 'archive_cached_links_fields', []):
-            value = getattr(obj, field)
-            value = [str(x) for x in value]
-            data['links'][field] = value
-        data['links']['history_current'] = str(obj.history_id)
-
+        raw_data = serializer.data
+        data = OrderedDict()
+        links = OrderedDict()
+        fields = serializer.Meta.fields
+        fields_extra = getattr(serializer.Meta, 'fields_extra', {})
+        for name in fields:
+            field_extra = fields_extra.get(name, {})
+            archive = field_extra.get('archive', 'include')
+            if archive == 'include':
+                link = field_extra.get('link')
+                if link is None:
+                    # Archived attribute
+                    data[name] = raw_data[name]
+                elif link == 'self':
+                    # Archived self-id
+                    data['id'] = str(raw_data[name])
+                elif link == 'to_one':
+                    value = getattr(obj, name + '_id')
+                    if value is not None:
+                        value = str(value)
+                    links[name] = value
+                else:
+                    assert link == 'from_many', 'Unhandled link "%s"' % link
+                    related = getattr(obj, name)
+                    links[name] = [str(rel.pk) for rel in related]
+            elif archive == 'history_id':
+                links[name] = str(obj.history_id)
+            else:
+                assert archive == 'omit'
+        data['links'] = links
         return data
 
     class Meta:
@@ -441,10 +628,9 @@ class HistoricalBrowserSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, BrowserSerializer):
         class Meta(BrowserSerializer.Meta):
-            fields = omit_some(
-                BrowserSerializer.Meta.fields,
-                'history_current', 'history', 'versions')
-            archive_cached_links_fields = ('versions',)
+            fields = (
+                'id', 'slug', 'name', 'note', 'versions', 'history',
+                'history_current')
 
     browser = HistoricalObjectField()
     browsers = SerializerMethodField('get_archive')
@@ -459,14 +645,11 @@ class HistoricalFeatureSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, FeatureSerializer):
         class Meta(FeatureSerializer.Meta):
-            fields = omit_some(
-                FeatureSerializer.Meta.fields,
-                'history_current', 'history', 'sections', 'supports',
-                'children')
-            read_only_fields = omit_some(
-                FeatureSerializer.Meta.read_only_fields, 'supports')
-            archive_link_fields = ('parent',)
-            archive_cached_links_fields = ('children', 'sections')
+            fields = (
+                'id', 'slug', 'mdn_uri', 'experimental', 'standardized',
+                'stable', 'obsolete', 'name',
+                'supports', 'parent', 'children', 'sections',
+                'history_current', 'history')
 
     feature = HistoricalObjectField()
     features = SerializerMethodField('get_archive')
@@ -481,9 +664,7 @@ class HistoricalMaturitySerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, MaturitySerializer):
         class Meta(MaturitySerializer.Meta):
-            fields = omit_some(
-                MaturitySerializer.Meta.fields,
-                'specifications', 'history_current', 'history')
+            pass
 
     maturity = HistoricalObjectField()
     maturities = SerializerMethodField('get_archive')
@@ -497,11 +678,7 @@ class HistoricalMaturitySerializer(HistoricalObjectSerializer):
 class HistoricalSectionSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, SectionSerializer):
-        class Meta(SectionSerializer.Meta):
-            fields = omit_some(
-                SectionSerializer.Meta.fields,
-                'features', 'history_current', 'history')
-            archive_link_fields = ('specification',)
+        pass
 
     section = HistoricalObjectField()
     sections = SerializerMethodField('get_archive')
@@ -515,12 +692,7 @@ class HistoricalSectionSerializer(HistoricalObjectSerializer):
 class HistoricalSpecificationSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, SpecificationSerializer):
-        class Meta(SpecificationSerializer.Meta):
-            fields = omit_some(
-                SpecificationSerializer.Meta.fields,
-                'sections', 'history_current', 'history')
-            archive_cached_links_fields = ('sections',)
-            archive_link_fields = ('maturity',)
+        pass
 
     specification = HistoricalObjectField()
     specifications = SerializerMethodField('get_archive')
@@ -534,10 +706,7 @@ class HistoricalSpecificationSerializer(HistoricalObjectSerializer):
 class HistoricalSupportSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, SupportSerializer):
-        class Meta(SupportSerializer.Meta):
-            fields = omit_some(
-                SupportSerializer.Meta.fields, 'history_current', 'history')
-            archive_link_fields = ('version', 'feature')
+        pass
 
     support = HistoricalObjectField()
     supports = SerializerMethodField('get_archive')
@@ -551,13 +720,7 @@ class HistoricalSupportSerializer(HistoricalObjectSerializer):
 class HistoricalVersionSerializer(HistoricalObjectSerializer):
 
     class ArchivedObject(ArchiveMixin, VersionSerializer):
-        class Meta(VersionSerializer.Meta):
-            fields = omit_some(
-                VersionSerializer.Meta.fields,
-                'supports', 'history_current', 'history')
-            read_only_fields = omit_some(
-                VersionSerializer.Meta.read_only_fields, 'supports')
-            archive_link_fields = ('browser',)
+        pass
 
     version = HistoricalObjectField()
     versions = SerializerMethodField('get_archive')

--- a/webplatformcompat/tests/__init__.py
+++ b/webplatformcompat/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the API app."""

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -1,3 +1,4 @@
+"""Common functionality for testing the API."""
 from django.contrib.auth.models import Group, User
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -10,7 +11,7 @@ from webplatformcompat.history import Changeset
 
 
 class TestMixin(object):
-    """Useful methods for testing"""
+    """Useful methods for testing."""
     maxDiff = None
     namespace = 'v1'
 
@@ -46,7 +47,7 @@ class TestMixin(object):
         return user
 
     def create(self, klass, _history_user=None, _history_date=None, **kwargs):
-        """Create a model, setting the historical relations"""
+        """Create a model, setting the historical relations."""
         obj = klass(**kwargs)
         obj._history_user = (
             _history_user or getattr(self, 'user', None) or self.login_user())
@@ -65,7 +66,7 @@ class TestMixin(object):
         return obj
 
     def normalizeData(self, data):
-        """Attempt to recursively turn data into a normalized representation"""
+        """Recursively turn data into a normalized representation."""
         if isinstance(data, six.string_types):
             return encoding.smart_text(data)
         elif hasattr(data, 'items'):
@@ -78,7 +79,7 @@ class TestMixin(object):
             return data
 
     def assertDataEqual(self, first, second):
-        """Normalize two values to basic types before testing equality"""
+        """Normalize two values to basic types before testing equality."""
         n_first = self.normalizeData(first)
         n_second = self.normalizeData(second)
         self.assertEqual(n_first, n_second)
@@ -99,9 +100,8 @@ class TestMixin(object):
 
 
 class TestCase(TestMixin, TestCase):
-    """TestCase with useful methods"""
-    pass
+    """TestCase with useful methods."""
 
 
 class APITestCase(TestMixin, BaseAPITestCase):
-    """APITestCase with useful methods"""
+    """APITestCase with useful methods."""

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -93,17 +93,9 @@ class TestMixin(object):
         """Get the primary key of the current history instance."""
         return obj.history.all()[0].pk
 
-    def history_pk_str(self, obj):
-        """Get the primary key of the current history as a string."""
-        return str(self.history_pk(obj))
-
     def history_pks(self, obj):
         """Get the primary keys of all the history instances."""
-        return obj.history.all().values_list('pk', flat=True)
-
-    def history_pks_str(self, obj):
-        """Get the primary keys of all the history instances as strings."""
-        return [str(pk) for pk in self.history_pks(obj)]
+        return list(obj.history.all().values_list('pk', flat=True))
 
 
 class TestCase(TestMixin, TestCase):

--- a/webplatformcompat/tests/test_cache.py
+++ b/webplatformcompat/tests/test_cache.py
@@ -156,52 +156,41 @@ class TestCache(TestCase):
             'name': {"en": "A Name"},
             'descendant_count': 0,
             'supports:PKList': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'support',
                 'pks': [],
             },
             'sections:PKList': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'section',
                 'pks': [],
             },
             'parent:PK': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'feature',
                 'pk': None,
             },
             'children:PKList': {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [],
-            },
-            'page_children:PKList': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'feature',
                 'pks': [],
             },
             'row_children:PKList': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'feature',
                 'pks': [],
             },
-            'descendants:PKList': {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [],
-            },
-            'row_descendants:PKList': {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [],
-            },
+            'row_children_pks': [],
+            'page_children_pks': [],
+            'descendant_pks': [],
+            'row_descendant_pks': [],
             'history:PKList': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'historicalfeature',
                 'pks': [feature.history.all()[0].pk],
             },
             'history_current:PK': {
-                'app': u'webplatformcompat',
+                'app': 'webplatformcompat',
                 'model': 'historicalfeature',
                 'pk': feature.history.all()[0].pk,
             },
@@ -224,37 +213,12 @@ class TestCache(TestCase):
         out = self.cache.feature_v1_serializer(feature)
         self.assertEqual(out['descendant_count'], 5)
         self.assertEqual(
-            out['descendants:PKList'],
-            {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [child1.pk, child2.pk, child21.pk, page2.pk, page1.pk]
-            }
-        )
+            out['descendant_pks'],
+            [child1.pk, child2.pk, child21.pk, page2.pk, page1.pk])
         self.assertEqual(
-            out['row_descendants:PKList'],
-            {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [child1.pk, child2.pk, child21.pk]
-            }
-        )
-        self.assertEqual(
-            out['page_children:PKList'],
-            {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [page1.pk]
-            }
-        )
-        self.assertEqual(
-            out['row_children:PKList'],
-            {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': [child1.pk, child2.pk]
-            }
-        )
+            out['row_descendant_pks'], [child1.pk, child2.pk, child21.pk])
+        self.assertEqual(out['page_children_pks'], [page1.pk])
+        self.assertEqual(out['row_children_pks'], [child1.pk, child2.pk])
 
     @override_settings(PAGINATE_VIEW_FEATURE=2)
     def test_feature_v1_serializer_paginated_descendants(self):
@@ -266,14 +230,7 @@ class TestCache(TestCase):
         feature = Feature.objects.get(id=feature.id)
         out = self.cache.feature_v1_serializer(feature)
         self.assertEqual(out['descendant_count'], 3)
-        self.assertEqual(
-            out['descendants:PKList'],
-            {
-                'app': u'webplatformcompat',
-                'model': 'feature',
-                'pks': []
-            }
-        )
+        self.assertEqual(out['descendant_pks'], [])
 
     def test_feature_v1_serializer_empty(self):
         self.assertEqual(None, self.cache.feature_v1_serializer(None))

--- a/webplatformcompat/tests/test_history.py
+++ b/webplatformcompat/tests/test_history.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Tests for `web-platform-compat.history."""
+"""Tests for simple_history extensions."""
 
 from json import loads
 
@@ -12,7 +11,7 @@ from webplatformcompat.models import Browser
 from .base import APITestCase
 
 
-class TestHistoryChangesetRequestMiddleware(APITestCase):
+class TestMiddleware(APITestCase):
     """Test the HistoryChangesetRequestMiddleware."""
 
     def test_post_with_changeset(self):

--- a/webplatformcompat/tests/test_models.py
+++ b/webplatformcompat/tests/test_models.py
@@ -89,6 +89,13 @@ class TestFeature(TestCase):
         parent.set_children_order(new_order)
         self.assertEqual(list(parent.children.all()), new_order)
 
+    def test_row_children(self):
+        parent, children = self.add_family()
+        self.create(
+            Feature, slug='page_child', parent=parent,
+            mdn_uri='{"en": "https://example.com/page"}')
+        self.assertEqual(parent.row_children, children)
+
 
 class TestMaturity(unittest.TestCase):
     def test_str(self):

--- a/webplatformcompat/tests/test_parsers.py
+++ b/webplatformcompat/tests/test_parsers.py
@@ -1,24 +1,141 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Tests for `web-platform-compat` renderers module."""
+"""Tests for JSON API RC1 parser."""
+from __future__ import unicode_literals
+from collections import OrderedDict
+from json import dumps
 
-from django.test import TestCase
+from django.utils.six import BytesIO
+from rest_framework.exceptions import ParseError
 
-from webplatformcompat.models import Browser
-from webplatformcompat.parsers import JsonApiParser
+from .base import TestCase
+from webplatformcompat.parsers import JsonApiRC1Parser
+from webplatformcompat.viewsets import FeatureViewSet
 
 
-class TestJsonApiRenderers(TestCase):
+class TestJsonApiRC1Parser(TestCase):
+    def parse(self, data):
+        stream = BytesIO(dumps(data).encode('utf8'))
+        parser = JsonApiRC1Parser()
+        view = FeatureViewSet()
+        return parser.parse(stream, None, {'view': view})
 
-    def setUp(self):
-        self.parser = JsonApiParser()
+    def test_simple(self):
+        resource = self.parse({
+            'features': {
+                'id': '1',
+                'slug': 'the_feature',
+                'name': {'en': 'The Feature'},
+                'links': {
+                    'parent': None,
+                    'children': ['2', '3']
+                }
+            }
+        })
+        expected = {
+            'id': '1',
+            'slug': 'the_feature',
+            'name': {'en': 'The Feature'},
+            'parent': None,
+            'children': ['2', '3']
+        }
+        self.assertDataEqual(resource, expected)
 
-    def test_model_to_resource_type(self):
-        self.assertEqual(
-            'browsers', self.parser.model_to_resource_type(Browser()))
-        self.assertEqual(
-            'historical_browsers',
-            self.parser.model_to_resource_type(Browser().history.model))
-        self.assertEqual(
-            'data',
-            self.parser.model_to_resource_type(None))
+    def test_complex(self):
+        resource = self.parse({
+            'features': {
+                'id': '1',
+                'slug': 'the_feature',
+                'name': {'en': 'The Feature'},
+                'links': {
+                    'parent': None,
+                    'children': ['2', '3']
+                }
+            },
+            'linked': {
+                'features': [
+                    {
+                        'id': '2',
+                        'slug': 'child2',
+                        'name': {'en': 'Child 2'},
+                        'links': {'parent': '1'},
+                    }, {
+                        'id': '3',
+                        'slug': 'child3',
+                        'name': {'en': 'Child 3'},
+                        'links': {'parent': '1'},
+                    }],
+            },
+            'meta': {
+                'foo': 'bar'
+            },
+            'other': {
+                'ignored': 'yep'
+            }
+        })
+        expected = {
+            'id': '1',
+            'slug': 'the_feature',
+            'name': {'en': 'The Feature'},
+            'parent': None,
+            'children': ['2', '3'],
+            '_view_extra': {
+                'features': [
+                    {
+                        'id': '2',
+                        'slug': 'child2',
+                        'name': {'en': 'Child 2'},
+                        'parent': '1',
+                    }, {
+                        'id': '3',
+                        'slug': 'child3',
+                        'name': {'en': 'Child 3'},
+                        'parent': '1',
+                    }],
+                'meta': {'foo': 'bar'},
+            }
+        }
+        self.assertDataEqual(resource, expected)
+
+    def test_duplicate_attribute_in_links(self):
+        data = {
+            'features': OrderedDict((
+                ('parent', None),
+                ('links', {'parent': None}),
+            ))
+        }
+        self.assertRaises(ParseError, self.parse, data)
+
+    def test_duplicate_link_in_attributes(self):
+        data = {
+            'features': OrderedDict((
+                ('links', {'parent': None}),
+                ('parent', None),
+            ))
+        }
+        self.assertRaises(ParseError, self.parse, data)
+
+    def test_view_extra_in_attributes(self):
+        data = {
+            'features': {
+                '_view_extra': 'foo'
+            }
+        }
+        self.assertRaises(ParseError, self.parse, data)
+
+    def test_view_extra_in_links(self):
+        data = {
+            'features': {
+                'links': {
+                    '_view_extra': 'foo'
+                }
+            }
+        }
+        self.assertRaises(ParseError, self.parse, data)
+
+    def test_meta_in_linked(self):
+        data = {
+            'linked': {
+                'meta': 'foo'
+            }
+        }
+        self.assertRaises(ParseError, self.parse, data)

--- a/webplatformcompat/tests/test_renderers.py
+++ b/webplatformcompat/tests/test_renderers.py
@@ -1,24 +1,346 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Tests for `web-platform-compat` renderers module."""
+"""Tests for API renderers."""
+from __future__ import unicode_literals
 
-from django.test import TestCase
+from django.test import RequestFactory
+from rest_framework.serializers import ListSerializer
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
+import mock
 
-from webplatformcompat.models import Browser
-from webplatformcompat.renderers import JsonApiRenderer
+from .base import TestCase
+from webplatformcompat.renderers import JsonApiRC1Renderer
+from webplatformcompat.serializers import BrowserSerializer, FeatureSerializer
 
 
 class TestJsonApiRenderers(TestCase):
+    media_type = 'application/vnd.api+json'
+    base_url = 'http://testserver/api/v1/'
 
     def setUp(self):
-        self.renderer = JsonApiRenderer()
+        self.renderer = JsonApiRC1Renderer()
 
-    def test_model_to_resource_type(self):
-        self.assertEqual(
-            'browsers', self.renderer.model_to_resource_type(Browser()))
-        self.assertEqual(
-            'historical_browsers',
-            self.renderer.model_to_resource_type(Browser().history.model))
-        self.assertEqual(
-            'data',
-            self.renderer.model_to_resource_type(None))
+    def make_context(self, status_code=200, url=None):
+        response = mock.Mock(spec_set=['status_code'])
+        response.status_code = status_code
+        if url:
+            request = RequestFactory().get(url)
+        else:
+            request = mock.Mock(spec_set=['build_absolute_uri'])
+            request.build_absolute_uri.side_effect = Exception('not called')
+        renderer_context = {
+            'response': response,
+            'request': request,
+            'fields_extra': FeatureSerializer.get_fields_extra(),
+        }
+        return renderer_context
+
+    def make_list(self, data_list, serializer):
+        list_serializer = ListSerializer(child=serializer)
+        return ReturnList(data_list, serializer=list_serializer)
+
+    def test_paginated_empty(self):
+        data = {
+            'count': 0,
+            'next': None,
+            'previous': None,
+            'results': self.make_list([], BrowserSerializer())
+        }
+        output = self.renderer.render(
+            data, self.media_type, self.make_context())
+        expected = {
+            "browsers": [],
+            "meta": {
+                "pagination": {
+                    "browsers": {
+                        "count": 0,
+                        "next": None,
+                        "previous": None,
+                    }
+                }
+            }
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_paginated_populated(self):
+        browser1 = {
+            'id': 1,
+            'slug': 'firefox_desktop',
+            'name': {'en': 'Firefox for Desktop'},
+            'note': None,
+            'versions': [100, 101],
+            'history_current': 200,
+            'history': [200]
+        }
+        browser2 = {
+            'id': 2,
+            'slug': 'edge',
+            'name': {'en': 'Edge'},
+            'note': None,
+            'versions': [300, 301],
+            'history_current': 400,
+            'history': [400]
+        }
+        results = self.make_list([browser1, browser2], BrowserSerializer())
+        data = {
+            'count': 2,
+            'next': None,
+            'previous': None,
+            'results': results
+        }
+        url = self.api_reverse('browser-list')
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(url=url))
+        expected = {
+            "browsers": [
+                {
+                    "id": "1",
+                    "slug": "firefox_desktop",
+                    "name": {"en": "Firefox for Desktop"},
+                    "note": None,
+                    "links": {
+                        "versions": ["100", "101"],
+                        "history_current": "200",
+                        "history": ["200"],
+                    }
+                },
+                {
+                    "id": "2",
+                    "slug": "edge",
+                    "name": {"en": "Edge"},
+                    "note": None,
+                    "links": {
+                        "versions": ["300", "301"],
+                        "history_current": "400",
+                        "history": ["400"],
+                    }
+                },
+
+            ],
+            "links": {
+                'browsers.versions': {
+                    'type': 'versions',
+                    'href': self.base_url + 'versions/{browsers.versions}',
+                },
+                'browsers.history_current': {
+                    'type': 'historical_browsers',
+                    'href': (
+                        self.base_url +
+                        'historical_browsers/{browsers.history_current}'),
+                },
+                'browsers.history': {
+                    'type': 'historical_browsers',
+                    'href': (
+                        self.base_url +
+                        'historical_browsers/{browsers.history}'),
+                },
+            },
+            "meta": {
+                "pagination": {
+                    "browsers": {
+                        "count": 2,
+                        "next": None,
+                        "previous": None,
+                    }
+                }
+            }
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_null_link(self):
+        data = ReturnDict((
+            ('id', 1),
+            ('slug', 'web'),
+            ('mdn_uri', None),
+            ('name', {'en': 'Web'}),
+            ('parent', None),
+            ('children', [2, 3, 4, 5, 6, 7]),
+        ), serializer=FeatureSerializer())
+        url = self.api_reverse('feature-detail', pk=1)
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(url=url))
+        expected = {
+            "features": {
+                "id": "1",
+                "slug": "web",
+                "mdn_uri": None,
+                "name": {"en": "Web"},
+                "links": {
+                    "parent": None,
+                    "children": ['2', '3', '4', '5', '6', '7']
+                }
+            },
+            "links": {
+                'features.parent': {
+                    'type': 'features',
+                    'href': self.base_url + 'features/{features.parent}',
+                },
+                'features.children': {
+                    'type': 'features',
+                    'href': self.base_url + 'features/{features.children}',
+                },
+            },
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_empty_data(self):
+        output = self.renderer.render(
+            None, self.media_type, self.make_context())
+        self.assertEqual(output.decode('utf8'), '')
+
+    def test_no_links(self):
+        data = ReturnDict((
+            ('id', 1),
+            ('slug', 'web'),
+            ('mdn_uri', None),
+            ('name', {'en': 'Web'}),
+        ), serializer=FeatureSerializer())
+        url = self.api_reverse('feature-detail', pk=1)
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(url=url))
+        expected = {
+            "features": {
+                "id": "1",
+                "slug": "web",
+                "mdn_uri": None,
+                "name": {"en": "Web"},
+            },
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_permission_denied(self):
+        data = {
+            'detail': "You do not have permission to perform this action."
+        }
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(status_code=403))
+        expected = {
+            'errors': [
+                {
+                    'detail': data['detail'],
+                    'status': '403'
+                }
+            ]
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_field_validation_error(self):
+        data = ReturnDict((
+            ('children', ['Set child.parent to add a child feature.']),
+        ), serializer=FeatureSerializer())
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(status_code=400))
+        expected = {
+            'errors': [
+                {
+                    'detail': 'Set child.parent to add a child feature.',
+                    'path': '/children',
+                    'status': '400'
+                }
+            ]
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_view_extra(self):
+        feature2 = {
+            'id': 2,
+            'slug': 'css',
+            'parent': 1
+        }
+        feature3 = {
+            'id': 3,
+            'slug': 'js',
+            'parent': 1
+        }
+        data = ReturnDict((
+            ('id', 1),
+            ('slug', 'web'),
+            ('mdn_uri', None),
+            ('name', {'en': 'Web'}),
+            ('parent', None),
+            ('children', [2, 3]),
+            ('_view_extra', {
+                'features': self.make_list(
+                    [feature2, feature3], FeatureSerializer()),
+                'meta': {'foo': 'bar'},
+            }),
+        ), serializer=FeatureSerializer())
+        url = self.api_reverse('viewfeatures-detail', pk=1)
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(url=url))
+        expected = {
+            "features": {
+                "id": "1",
+                "slug": "web",
+                "mdn_uri": None,
+                "name": {"en": "Web"},
+                "links": {
+                    "parent": None,
+                    "children": ["2", "3"],
+                },
+            },
+            "linked": {
+                "features": [
+                    {
+                        "id": "2",
+                        "slug": "css",
+                        "links": {"parent": "1"},
+                    }, {
+                        "id": "3",
+                        "slug": "js",
+                        "links": {"parent": "1"},
+                    }
+                ]
+            },
+            "links": {
+                "features.children": {
+                    "type": "features",
+                    "href": self.base_url + "features/{features.children}",
+                },
+                "features.parent": {
+                    "type": "features",
+                    "href": self.base_url + "features/{features.parent}",
+                },
+            },
+            "meta": {
+                "foo": "bar"
+            }
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_linked_error(self):
+        data = {
+            '_view_extra': {
+                'features': {
+                    0: {'parent': ['Feature must be a descendant.']},
+                }
+            }
+        }
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(status_code=400))
+        expected = {
+            'errors': [{
+                "status": "400",
+                "path": "/linked.features.0.parent",
+                "detail": "Feature must be a descendant."
+            }]
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)
+
+    def test_subject_error(self):
+        data = {
+            '_view_extra': {
+                'features': {
+                    None: {'children': ['MYSTERY ERROR.']},
+                }
+            }
+        }
+        output = self.renderer.render(
+            data, self.media_type, self.make_context(status_code=400))
+        expected = {
+            'errors': [{
+                "status": "400",
+                "path": "/linked.features.subject.children",
+                "detail": "MYSTERY ERROR."
+            }]
+        }
+        self.assertJSONEqual(output.decode('utf8'), expected)

--- a/webplatformcompat/tests/test_serializers.py
+++ b/webplatformcompat/tests/test_serializers.py
@@ -1,230 +1,134 @@
 # -*- coding: utf-8 -*-
 """Tests for API serializers."""
 
-from json import dumps
-
 from webplatformcompat.models import (
     Browser, Feature, Maturity, Section, Specification, Version)
-from webplatformcompat.serializers import HistoricalMaturitySerializer
+from webplatformcompat.serializers import (
+    BrowserSerializer, FeatureSerializer, HistoricalFeatureSerializer,
+    HistoricalMaturitySerializer, SpecificationSerializer, UserSerializer)
 
-from .base import APITestCase as BaseCase
-
-
-class APITestCase(BaseCase):
-    """Add integration test helpers to APITestCase."""
-    longMessage = True  # Display inequalities and message parameter
-
-    def get_via_json_api(self, url):
-        """Get instance via API."""
-        response = self.client.get(url, HTTP_ACCEPT='application/vnd.api+json')
-        self.assertEqual(200, response.status_code, response.data)
-        return response
-
-    def update_via_json_api(self, url, data, expected_status=200):
-        """Update instance via API using JSON-API formatted data."""
-        json_data = dumps(data)
-        content_type = 'application/vnd.api+json'
-        response = self.client.put(
-            url, data=json_data, content_type=content_type,
-            HTTP_ACCEPT='application/vnd.api+json')
-        self.assertEqual(expected_status, response.status_code, response.data)
-        return response
+from .base import TestCase
 
 
-class TestHistoricalModelSerializer(APITestCase):
-    """Test common serializer functionality through BrowserSerializer."""
+class TestBrowserSerializer(TestCase):
+    """Test BrowserSerializer and common historical functionality."""
 
     def setUp(self):
         self.browser = self.create(
             Browser, slug='browser', name={'en': 'Old Name'})
-        self.url = self.api_reverse('browser-detail', pk=self.browser.pk)
 
-    def test_put_history_current(self):
+    def add_versions(self):
+        v1 = self.create(Version, browser=self.browser, version='1.0')
+        v2 = self.create(Version, browser=self.browser, version='2.0')
+        return v1, v2
+
+    def test_set_history_current_to_old(self):
         old_history_id = self.browser.history.latest('history_date').history_id
         self.browser.name = {'en': 'Browser'}
         self.browser.save()
-        data = {
-            'browsers': {
-                'links': {
-                    'history_current': str(old_history_id)
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        current_history_id = self.browser.history.all()[0].history_id
-        self.assertNotEqual(old_history_id, current_history_id)
-        histories = self.browser.history.all()
-        self.assertEqual(3, len(histories))
-        expected_data = {
-            "id": self.browser.pk,
-            "slug": "browser",
-            "name": {"en": "Old Name"},
-            "note": None,
-            'history': [h.pk for h in histories],
-            'history_current': current_history_id,
-            'versions': [],
-        }
-        self.assertDataEqual(response.data, expected_data)
 
-    def test_put_history_current_wrong_browser_fails(self):
+        data = {'history_current': old_history_id}
+        serializer = BrowserSerializer(self.browser, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_browser = serializer.save()
+        histories = new_browser.history.all()
+        self.assertEqual(3, len(histories))
+        self.assertEqual(new_browser.name, {"en": "Old Name"})
+
+    def test_set_history_current_to_wrong_browser_fails(self):
         other_browser = self.create(
             Browser, slug='other-browser', name={'en': 'Other Browser'})
         bad_history_id = other_browser.history.all()[0].history_id
-        data = {
-            'browsers': {
-                'slug': 'browser',
-                'links': {
-                    'history_current': str(bad_history_id)
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data, 400)
-        expected_data = {
-            'history_current': ['Invalid history ID for this object']
-        }
-        self.assertDataEqual(response.data, expected_data)
 
-    def test_put_history_same(self):
+        data = {'history_current': bad_history_id}
+        serializer = BrowserSerializer(self.browser, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        expected = {'history_current': ['Invalid history ID for this object']}
+        self.assertEqual(serializer.errors, expected)
+
+    def test_set_history_current_to_same(self):
         self.browser.name = {'en': 'Browser'}
         self.browser.save()
         current_history_id = self.browser.history.all()[0].history_id
-        data = {
-            'browsers': {
-                'links': {
-                    'history_current': str(current_history_id)
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        new_history_id = self.browser.history.all()[0].history_id
+
+        data = {'history_current': current_history_id}
+        serializer = BrowserSerializer(self.browser, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_browser = serializer.save()
+        new_history_id = new_browser.history.all()[0].history_id
         self.assertNotEqual(new_history_id, current_history_id)
-        histories = self.browser.history.all()
+        histories = new_browser.history.all()
         self.assertEqual(3, len(histories))
-        expected_data = {
-            "id": self.browser.pk,
-            "slug": "browser",
-            "name": {"en": "Browser"},
-            "note": None,
-            'history': [h.pk for h in histories],
-            'history_current': new_history_id,
-            'versions': [],
-        }
-        self.assertDataEqual(response.data, expected_data)
 
-
-class TestBrowserSerializer(APITestCase):
-    """Test BrowserSerializer through the view."""
-    def setUp(self):
-        self.browser = self.create(
-            Browser, slug='browser', name={'en': 'Browser'})
-        self.v1 = self.create(Version, browser=self.browser, version='1.0')
-        self.v2 = self.create(Version, browser=self.browser, version='2.0')
-        self.url = self.api_reverse('browser-detail', pk=self.browser.pk)
-
-    def test_versions_change_order(self):
-        data = {
-            'browsers': {
-                'links': {
-                    'versions': [str(self.v2.pk), str(self.v1.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        expected_versions = [v.pk for v in (self.v2, self.v1)]
-        actual_versions = response.data['versions']
-        self.assertEqual(expected_versions, actual_versions)
+    def test_set_versions_change_order(self):
+        v1, v2 = self.add_versions()
+        set_order = [v2.pk, v1.pk]
+        data = {'versions': set_order}
+        serializer = BrowserSerializer(self.browser, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_browser = serializer.save()
+        new_order = list(new_browser.versions.values_list('pk', flat=True))
+        self.assertEqual(new_order, set_order)
 
     def test_versions_same_order(self):
-        data = {
-            'browsers': {
-                'links': {
-                    'versions': [str(self.v1.pk), str(self.v2.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        expected_versions = [v.pk for v in (self.v1, self.v2)]
-        actual_versions = response.data['versions']
-        self.assertEqual(expected_versions, actual_versions)
+        v1, v2 = self.add_versions()
+        set_order = [v1.pk, v2.pk]
+        data = {'versions': set_order}
+        serializer = BrowserSerializer(self.browser, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_browser = serializer.save()
+        new_order = list(new_browser.versions.values_list('pk', flat=True))
+        self.assertEqual(new_order, set_order)
 
 
-class TestFeatureSerializer(APITestCase):
-    """Test FeatureSerializer through the view."""
+class TestFeatureSerializer(TestCase):
+    """Test FeatureSerializer."""
 
     def setUp(self):
         self.parent = self.create(Feature, slug='parent')
         self.feature = self.create(Feature, slug='feature', parent=self.parent)
         self.child1 = self.create(Feature, slug='child1', parent=self.feature)
         self.child2 = self.create(Feature, slug='child2', parent=self.feature)
-        self.url = self.api_reverse('feature-detail', pk=self.feature.pk)
 
-    def test_original_order(self):
-        response = self.get_via_json_api(self.url)
-        expected_children = [v.pk for v in (self.child1, self.child2)]
-        actual_children = response.data['children']
-        self.assertEqual(expected_children, actual_children)
+    def test_set_children_change_order(self):
+        set_order = [self.child2.pk, self.child1.pk]
+        data = {'children': set_order}
+        serializer = FeatureSerializer(self.feature, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_feature = serializer.save()
+        actual_children = list(
+            new_feature.get_children().values_list('pk', flat=True))
+        self.assertEqual(actual_children, set_order)
 
-    def test_children_change_order(self):
-        data = {
-            'features': {
-                'links': {
-                    'children': [str(self.child2.pk), str(self.child1.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        expected_children = [v.pk for v in (self.child2, self.child1)]
-        actual_children = response.data['children']
-        self.assertEqual(expected_children, actual_children)
+    def test_set_children_same_order(self):
+        set_order = [self.child1.pk, self.child2.pk]
+        data = {'children': set_order}
+        serializer = FeatureSerializer(self.feature, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_feature = serializer.save()
+        actual_children = list(
+            new_feature.get_children().values_list('pk', flat=True))
+        self.assertEqual(actual_children, set_order)
 
-    def test_children_same_order(self):
-        data = {
-            'features': {
-                'links': {
-                    'children': [str(self.child1.pk), str(self.child2.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        expected_children = [v.pk for v in (self.child1, self.child2)]
-        actual_children = response.data['children']
-        self.assertEqual(expected_children, actual_children)
+    def test_set_children_omit_child_fails(self):
+        data = {'children': [self.child1.pk]}
+        serializer = FeatureSerializer(self.feature, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        expected = {
+            'children': ['All child features must be included in children.']}
+        self.assertEqual(serializer.errors, expected)
 
-    def test_children_remove_element_fails(self):
-        data = {
-            'features': {
-                'links': {
-                    'children': [str(self.child1.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(
-            self.url, data, expected_status=400)
-        expected_error = ['All child features must be included in children.']
-        actual_error = response.data['children']
-        self.assertEqual(expected_error, actual_error)
-
-    def test_children_add_element_fails(self):
+    def test_set_children_add_element_fails(self):
         new_child = self.create(Feature, slug='nkotb')
-        data = {
-            'features': {
-                'links': {
-                    'children': [
-                        str(self.child1.pk),
-                        str(self.child2.pk),
-                        str(new_child.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(
-            self.url, data, expected_status=400)
-        expected_error = ['Set child.parent to add a child feature.']
-        actual_error = response.data['children']
-        self.assertEqual(expected_error, actual_error)
+        data = {'children': [self.child1.pk, self.child2.pk, new_child.pk]}
+        serializer = FeatureSerializer(self.feature, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        expected = {'children': ['Set child.parent to add a child feature.']}
+        self.assertEqual(serializer.errors, expected)
 
 
-class TestSpecificationSerializer(APITestCase):
-    """Test SpecificationSerializer through the view."""
+class TestSpecificationSerializer(TestCase):
+    """Test SpecificationSerializer."""
 
     def setUp(self):
         maturity = self.create(
@@ -242,111 +146,88 @@ class TestSpecificationSerializer(APITestCase):
             Section, specification=self.spec,
             name={'en': "The 'animation-iteration-count' property"},
             subpath={'en': "#animation-iteration-count"})
-        self.url = self.api_reverse('specification-detail', pk=self.spec.pk)
 
-    def test_update_without_sections(self):
-        data = {
-            'specifications': {
-                'name': {'en': 'CSS3 Animations'}
-            }
-        }
-        self.update_via_json_api(self.url, data)
-        spec = Specification.objects.get(id=self.spec.id)
-        self.assertEqual({'en': 'CSS3 Animations'}, spec.name)
+    def test_set_name_without_sections(self):
+        data = {'name': {'en': 'CSS3 Animations'}}
+        serializer = SpecificationSerializer(
+            self.spec, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_spec = serializer.save()
+        self.assertEqual(new_spec.name, {'en': 'CSS3 Animations'})
 
-    def test_sections_change_order(self):
-        data = {
-            'specifications': {
-                'links': {
-                    'sections': [str(self.s45.pk), str(self.s46.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        expected_sections = [self.s45.pk, self.s46.pk]
-        actual_sections = response.data['sections']
-        self.assertEqual(expected_sections, actual_sections)
+    def test_set_sections_to_new_order(self):
+        set_order = [self.s45.pk, self.s46.pk]
+        serializer = SpecificationSerializer(
+            self.spec, data={'sections': set_order}, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_spec = serializer.save()
+        new_order = list(new_spec.sections.values_list('pk', flat=True))
+        self.assertEqual(new_order, set_order)
 
     def test_sections_same_order(self):
-        data = {
-            'specifications': {
-                'links': {
-                    'sections': [str(self.s46.pk), str(self.s45.pk)]
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data)
-        expected_sections = [self.s46.pk, self.s45.pk]
-        actual_sections = response.data['sections']
-        self.assertEqual(expected_sections, actual_sections)
+        set_order = [self.s46.pk, self.s45.pk]
+        serializer = SpecificationSerializer(
+            self.spec, data={'sections': set_order}, partial=True)
+        self.assertTrue(serializer.is_valid())
+        new_spec = serializer.save()
+        new_order = list(new_spec.sections.values_list('pk', flat=True))
+        self.assertEqual(new_order, set_order)
 
     def test_set_and_revert_maturity(self):
         old_maturity_id = self.spec.maturity.id
         old_history_id = self.spec.history.all()[0].history_id
         new_maturity = self.create(
             Maturity, slug='FD', name={'en': 'Final Draft'})
-        data_set_maturity = {
-            'specifications': {
-                'links': {
-                    'maturity': str(new_maturity.id)
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data_set_maturity)
-        self.assertEqual(response.data['maturity'], new_maturity.id)
+        serializer_set = SpecificationSerializer(
+            self.spec, data={'maturity': new_maturity.id}, partial=True)
+        self.assertTrue(serializer_set.is_valid())
+        new_spec = serializer_set.save()
+        self.assertEqual(new_spec.maturity, new_maturity)
 
-        data_revert = {
-            'specifications': {
-                'links': {
-                    'history_current': old_history_id
-                }
-            }
-        }
-        response = self.update_via_json_api(self.url, data_revert)
-        self.assertEqual(response.data['maturity'], old_maturity_id)
+        serializer_revert = SpecificationSerializer(
+            new_spec, data={'history_current': old_history_id}, partial=True)
+        self.assertTrue(serializer_revert.is_valid())
+        reverted_spec = serializer_revert.save()
+        self.assertEqual(reverted_spec.maturity_id, old_maturity_id)
 
 
-class TestUserSerializer(APITestCase):
-    """Test UserSerializer through the view."""
-    def test_get(self):
-        self.login_user()
-        url = self.api_reverse('user-detail', pk=self.user.pk)
-        response = self.get_via_json_api(url)
-        actual_data = response.data
-        self.assertEqual(0, actual_data['agreement'])
-        self.assertEqual(['change-resource'], actual_data['permissions'])
+class TestUserSerializer(TestCase):
+    """Test UserSerializer."""
+    def test_to_representation(self):
+        user = self.login_user()
+        serializer = UserSerializer()
+        representation = serializer.to_representation(user)
+        self.assertEqual(representation['agreement'], 0)
+        self.assertEqual(representation['permissions'], ['change-resource'])
 
 
-class TestHistoricalFeatureSerializer(APITestCase):
+class TestHistoricalFeatureSerializer(TestCase):
     """Test HistoricalFeatureSerializer, which has archive fields."""
-    def test_get_history_no_parent(self):
+    def test_to_representation_no_parent(self):
         feature = self.create(
             Feature, slug="the_feature", name={"en": "The Feature"})
         history = feature.history.all()[0]
-        url = self.api_reverse('historicalfeature-detail', pk=history.pk)
-        response = self.get_via_json_api(url)
-        actual_links = response.data['archived_representation']['links']
-        actual_sections = actual_links['sections']
-        self.assertEqual([], actual_sections)
-        actual_parent = actual_links['parent']
-        self.assertIsNone(actual_parent)
+        serializer = HistoricalFeatureSerializer()
+        representation = serializer.to_representation(history)
+        self.assertEqual(representation['object_id'], feature.pk)
+        links = representation['archived_representation']['links']
+        self.assertEqual(links['sections'], [])
+        self.assertEqual(links['parent'], None)
 
-    def test_get_history_sections_parent(self):
+    def test_to_representation_with_parent(self):
         parent = self.create(
             Feature, slug="the_parent", name={"en": "The Parent"})
         feature = self.create(
             Feature, slug="the_feature", name={"en": "The Feature"},
             parent=parent)
         history = feature.history.all()[0]
-        url = self.api_reverse('historicalfeature-detail', pk=history.pk)
-        response = self.get_via_json_api(url)
-        expected_parent = str(parent.pk)
-        actual_links = response.data['archived_representation']['links']
-        actual_parent = actual_links['parent']
-        self.assertEqual(expected_parent, actual_parent)
+        serializer = HistoricalFeatureSerializer()
+        representation = serializer.to_representation(history)
+        links = representation['archived_representation']['links']
+        self.assertEqual(links['parent'], str(parent.pk))
 
 
-class TestHistoricalMaturitySerializer(APITestCase):
+class TestHistoricalMaturitySerializer(TestCase):
     """Test HistoricalMaturitySerializer."""
     def test_fields_extra(self):
         maturity = self.create(

--- a/webplatformcompat/tests/test_view_serializers.py
+++ b/webplatformcompat/tests/test_view_serializers.py
@@ -1,37 +1,47 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-Tests for web-platform-compat.view_serializers.
-
-TODO: Refactor this code to be more unit tests than integration tests.
-This should wait until bug 1153288 (Reimplement DRF serializers and renderer)
-"""
+"""Tests for view serializers."""
 from __future__ import unicode_literals
-from json import dumps, loads
 
 from django.test.utils import override_settings
+from drf_cached_instances.models import CachedQueryset
+from rest_framework.test import APIRequestFactory
+from rest_framework.versioning import NamespaceVersioning
 
-from webplatformcompat.history import Changeset
+from webplatformcompat.cache import Cache
+from webplatformcompat.history import Changeset, HistoricalRecords
 from webplatformcompat.models import (
     Browser, Feature, Maturity, Section, Specification, Support, Version)
 from webplatformcompat.view_serializers import (
-    DjangoResourceClient, ViewFeatureExtraSerializer)
+    DjangoResourceClient, ViewFeatureSerializer, ViewFeatureExtraSerializer,
+    ViewFeatureListSerializer)
 
-from .base import APITestCase, TestCase
+from .base import TestCase
 
 
-class TestViewFeatureViewSet(APITestCase):
+class TestViewFeatureViewSet(TestCase):
     """Test /view_features/<feature_id>."""
 
     baseUrl = 'http://testserver'
 
-    def test_get_list(self):
+    def make_context(self, url, **kwargs):
+        """Create a context similar to a view."""
+        request = APIRequestFactory().get(url)
+        request.version = self.namespace
+        request.versioning_scheme = NamespaceVersioning()
+        context = {'request': request}
+        context.update(**kwargs)
+        return context
+
+    def test_list_representation(self):
         feature = self.create(Feature, slug='feature')
+        queryset = Feature.objects.all()
         url = self.api_reverse('viewfeatures-list')
-        response = self.client.get(url, HTTP_ACCEPT="application/vnd.api+json")
-        self.assertEqual(200, response.status_code, response.data)
+        serializer = ViewFeatureListSerializer(
+            queryset, many=True, context=self.make_context(url))
+        representation = serializer.to_representation(queryset)
+        self.assertEqual(len(representation), 1)
         detail_url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        self.assertContains(response, detail_url)
+        self.assertEqual(representation[0]['href'], self.baseUrl + detail_url)
 
     def setup_minimal(self):
         feature = self.create(Feature, slug='feature')
@@ -48,6 +58,7 @@ class TestViewFeatureViewSet(APITestCase):
         feature.sections = [section]
         self.changeset.closed = True
         self.changeset.save()
+        feature = Feature.objects.get(id=feature.id)  # Clear cached properties
         return {
             'feature': feature,
             'browser': browser,
@@ -69,74 +80,62 @@ class TestViewFeatureViewSet(APITestCase):
         version = resources['version']
         specification = resources['specification']
         url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url)
-
-        expected_json = {
-            "features": {
-                "id": str(feature.id),
-                "mdn_uri": None,
-                "slug": "feature",
-                "experimental": False,
-                "standardized": True,
-                "stable": True,
-                "obsolete": False,
-                "name": None,
-                "links": {
-                    "sections": [str(section.pk)],
-                    "supports": [str(support.pk)],
-                    "parent": None,
-                    "children": [],
-                    "history_current": self.history_pk_str(feature),
-                    "history": self.history_pks_str(feature),
-                }
-            },
-            "linked": {
+        serializer = ViewFeatureSerializer(context=self.make_context(url))
+        representation = serializer.to_representation(feature)
+        expected_representation = {
+            "id": feature.id,
+            "mdn_uri": None,
+            "slug": "feature",
+            "experimental": False,
+            "standardized": True,
+            "stable": True,
+            "obsolete": False,
+            "name": None,
+            "sections": [section.pk],
+            "supports": [support.pk],
+            "parent": None,
+            "children": [],
+            "history_current": self.history_pk(feature),
+            "history": self.history_pks(feature),
+            "_view_extra": {
                 "browsers": [{
-                    "id": str(browser.pk),
+                    "id": browser.pk,
                     "slug": "chrome_desktop",
                     "name": {"en": "Browser"},
                     "note": None,
-                    "links": {
-                        "history_current": self.history_pk_str(browser),
-                        "history": self.history_pks_str(browser),
-                    }
+                    "history_current": self.history_pk(browser),
+                    "history": self.history_pks(browser),
                 }],
                 "features": [],
                 "maturities": [{
-                    "id": str(maturity.id),
+                    "id": maturity.id,
                     "slug": "maturity",
                     "name": {"en": "Maturity"},
-                    "links": {
-                        "history_current": self.history_pk_str(maturity),
-                        "history": self.history_pks_str(maturity),
-                    }
+                    "history_current": self.history_pk(maturity),
+                    "history": self.history_pks(maturity),
                 }],
                 "sections": [{
-                    "id": str(section.id),
+                    "id": section.id,
                     "number": None,
                     "name": None,
                     "subpath": None,
                     "note": None,
-                    "links": {
-                        "specification": str(specification.id),
-                        "history_current": self.history_pk_str(section),
-                        "history": self.history_pks_str(section),
-                    }
+                    "specification": specification.id,
+                    "history_current": self.history_pk(section),
+                    "history": self.history_pks(section),
                 }],
                 "specifications": [{
-                    "id": str(specification.id),
+                    "id": specification.id,
                     "slug": "spec",
                     "mdn_key": None,
                     "name": {"en": "Specification"},
                     "uri": None,
-                    "links": {
-                        "maturity": str(maturity.id),
-                        "history_current": self.history_pk_str(specification),
-                        "history": self.history_pks_str(specification),
-                    }
+                    "maturity": maturity.id,
+                    "history_current": self.history_pk(specification),
+                    "history": self.history_pks(specification),
                 }],
                 "supports": [{
-                    "id": str(support.id),
+                    "id": support.id,
                     "support": "yes",
                     "prefix": None,
                     "prefix_mandatory": False,
@@ -146,15 +145,13 @@ class TestViewFeatureViewSet(APITestCase):
                     "default_config": None,
                     "protected": False,
                     "note": None,
-                    "links": {
-                        "version": str(version.id),
-                        "feature": str(feature.id),
-                        "history_current": self.history_pk_str(support),
-                        "history": self.history_pks_str(support),
-                    }
+                    "version": version.id,
+                    "feature": feature.id,
+                    "history_current": self.history_pk(support),
+                    "history": self.history_pks(support),
                 }],
                 "versions": [{
-                    "id": str(version.id),
+                    "id": version.id,
                     "version": None,
                     "release_day": None,
                     "retirement_day": None,
@@ -162,195 +159,54 @@ class TestViewFeatureViewSet(APITestCase):
                     "release_notes_uri": None,
                     "note": None,
                     "order": 0,
-                    "links": {
-                        "browser": str(browser.id),
-                        "history_current": self.history_pk_str(version),
-                        "history": self.history_pks_str(version),
-                    }
+                    "browser": browser.id,
+                    "history_current": self.history_pk(version),
+                    "history": self.history_pks(version),
                 }],
-            },
-            "links": {
-                "browsers.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_browsers/"
-                        "{browsers.history}"),
-                    "type": "historical_browsers"
-                },
-                "browsers.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_browsers/"
-                        "{browsers.history_current}"),
-                    "type": "historical_browsers"
-                },
-                "features.children": {
-                    "href": (
-                        self.baseUrl + "/api/v1/features/"
-                        "{features.children}"),
-                    "type": "features"
-                },
-                "features.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_features/"
-                        "{features.history}"),
-                    "type": "historical_features"
-                },
-                "features.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_features/"
-                        "{features.history_current}"),
-                    "type": "historical_features"
-                },
-                "features.parent": {
-                    "href": (
-                        self.baseUrl + "/api/v1/features/"
-                        "{features.parent}"),
-                    "type": "features"
-                },
-                "features.sections": {
-                    "href": (
-                        self.baseUrl + "/api/v1/sections/"
-                        "{features.sections}"),
-                    "type": "sections"
-                },
-                "features.supports": {
-                    "href": (
-                        self.baseUrl + "/api/v1/supports/"
-                        "{features.supports}"),
-                    "type": "supports"
-                },
-                "maturities.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_maturities/"
-                        "{maturities.history}"),
-                    "type": "historical_maturities"
-                },
-                "maturities.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_maturities/"
-                        "{maturities.history_current}"),
-                    "type": "historical_maturities"
-                },
-                "sections.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_sections/"
-                        "{sections.history}"),
-                    "type": "historical_sections"
-                },
-                "sections.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_sections/"
-                        "{sections.history_current}"),
-                    "type": "historical_sections"
-                },
-                "sections.specification": {
-                    "href": (
-                        self.baseUrl + "/api/v1/specifications/"
-                        "{sections.specification}"),
-                    "type": "specifications"
-                },
-                "specifications.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_specifications/"
-                        "{specifications.history}"),
-                    "type": "historical_specifications"
-                },
-                "specifications.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_specifications/"
-                        "{specifications.history_current}"),
-                    "type": "historical_specifications"
-                },
-                "specifications.maturity": {
-                    "href": (
-                        self.baseUrl + "/api/v1/maturities/"
-                        "{specifications.maturity}"),
-                    "type": "maturities"
-                },
-                "supports.feature": {
-                    "href": (
-                        self.baseUrl + "/api/v1/features/"
-                        "{supports.feature}"),
-                    "type": "features"
-                },
-                "supports.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_supports/"
-                        "{supports.history}"),
-                    "type": "historical_supports"
-                },
-                "supports.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_supports/"
-                        "{supports.history_current}"),
-                    "type": "historical_supports"
-                },
-                "supports.version": {
-                    "href": (
-                        self.baseUrl + "/api/v1/versions/"
-                        "{supports.version}"),
-                    "type": "versions"
-                },
-                "versions.browser": {
-                    "href": (
-                        self.baseUrl + "/api/v1/browsers/"
-                        "{versions.browser}"),
-                    "type": "browsers"
-                },
-                "versions.history": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_versions/"
-                        "{versions.history}"),
-                    "type": "historical_versions"
-                },
-                "versions.history_current": {
-                    "href": (
-                        self.baseUrl + "/api/v1/historical_versions/"
-                        "{versions.history_current}"),
-                    "type": "historical_versions"
-                },
-            },
-            "meta": {
-                "compat_table": {
-                    "tabs": [
-                        {
-                            "name": {"en": "Desktop Browsers"},
-                            "browsers": [str(browser.pk)]
+                "meta": {
+                    "compat_table": {
+                        "tabs": [
+                            {
+                                "name": {"en": "Desktop Browsers"},
+                                "browsers": [str(browser.pk)]
+                            },
+                        ],
+                        "supports": {
+                            str(feature.pk): {
+                                str(browser.pk): [str(support.pk)],
+                            }
                         },
-                    ],
-                    "supports": {
-                        str(feature.pk): {
-                            str(browser.pk): [str(support.pk)],
-                        }
-                    },
-                    "child_pages": False,
-                    "pagination": {
-                        "linked.features": {
-                            "previous": None,
-                            "next": None,
-                            "count": 0,
+                        "child_pages": False,
+                        "pagination": {
+                            "linked.features": {
+                                "previous": None,
+                                "next": None,
+                                "count": 0,
+                            },
                         },
-                    },
-                    "languages": ['en'],
-                    "notes": {},
+                        "languages": ['en'],
+                        "notes": {},
+                    }
                 }
             }
         }
-        actual_json = loads(response.content.decode('utf-8'))
-        self.assertDataEqual(expected_json, actual_json)
+        self.assertEqual(representation, expected_representation)
 
     def test_canonical_removed(self):
         """zxx (non-linguistic, canonical) does not appear in languages."""
         resources = self.setup_minimal()
         feature = resources['feature']
         del self.changeset
-        self.create(Feature, parent=feature, name='{"zxx": "canonical"}')
+        self.create(
+            Feature, parent=feature, slug='child', name='{"zxx": "canonical"}')
         self.changeset.closed = True
         self.changeset.save()
+        feature = Feature.objects.get(pk=feature.pk)
         url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url)
-        actual_json = loads(response.content.decode('utf-8'))
-        actual_langs = actual_json['meta']['compat_table']['languages']
-        self.assertEqual(['en'], actual_langs)
+        serializer = ViewFeatureSerializer(context=self.make_context(url))
+        representation = serializer.to_representation(feature)
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        self.assertEqual(compat_table['languages'], ['en'])
 
     def test_multiple_versions(self):
         """Meta section spells out significant versions."""
@@ -373,43 +229,47 @@ class TestViewFeatureViewSet(APITestCase):
         self.changeset.save()
 
         url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url)
-        actual_json = loads(response.content.decode('utf-8'))
+        serializer = ViewFeatureSerializer(context=self.make_context(url))
+        representation = serializer.to_representation(feature)
+        compat_table = representation['_view_extra']['meta']['compat_table']
         expected_supports = {
             str(feature.pk): {
                 str(browser.pk): [str(support1.pk), str(support3.pk)],
             }
         }
-        actual_supports = actual_json['meta']['compat_table']['supports']
-        self.assertDataEqual(expected_supports, actual_supports)
+        self.assertEqual(compat_table['supports'], expected_supports)
 
     def setup_feature_tree(self):
         feature = self.create(Feature, slug='feature')
-        self.create(Feature, slug='child1', parent=feature)
-        self.create(Feature, slug='child2', parent=feature)
-        self.create(Feature, slug='child3', parent=feature)
+        for count in range(3):
+            self.create(Feature, slug='child%d' % count, parent=feature)
         self.changeset.closed = True
         self.changeset.save()
+        feature = Feature.objects.get(id=feature.id)  # Clear cached properties
         return feature
 
     @override_settings(PAGINATE_VIEW_FEATURE=2)
     def test_large_feature_tree(self):
         feature = self.setup_feature_tree()
         url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url, {'child_pages': True})
-        actual_json = loads(response.content.decode('utf-8'))
+        context = self.make_context(url, include_child_pages=True)
+        serializer = ViewFeatureSerializer(context=context)
+        representation = serializer.to_representation(feature)
+        next_page = url + '?child_pages=1&page=2'
         expected_pagination = {
             'linked.features': {
                 'previous': None,
-                'next': self.baseUrl + url + '?child_pages=1&page=2',
+                'next': self.baseUrl + next_page,
                 'count': 3,
             }
         }
-        actual_pagination = actual_json['meta']['compat_table']['pagination']
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_pagination = compat_table['pagination']
         self.assertDataEqual(expected_pagination, actual_pagination)
 
-        response = self.client.get(url, {'child_pages': True, 'page': 2})
-        actual_json = loads(response.content.decode('utf-8'))
+        context2 = self.make_context(next_page, include_child_pages=True)
+        serializer2 = ViewFeatureSerializer(context=context2)
+        representation = serializer2.to_representation(feature)
         expected_pagination = {
             'linked.features': {
                 'previous': self.baseUrl + url + '?child_pages=1&page=1',
@@ -417,25 +277,80 @@ class TestViewFeatureViewSet(APITestCase):
                 'count': 3,
             }
         }
-        actual_pagination = actual_json['meta']['compat_table']['pagination']
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_pagination = compat_table['pagination']
+        self.assertEqual(expected_pagination, actual_pagination)
+
+    @override_settings(PAGINATE_VIEW_FEATURE=2)
+    def test_large_feature_tree_cached_feature(self):
+        feature = self.setup_feature_tree()
+        cached_qs = CachedQueryset(
+            Cache(), Feature.objects.all(), primary_keys=[feature.pk])
+        cached_feature = cached_qs.get(pk=feature.pk)
+        self.assertEqual(cached_feature.pk, feature.id)
+        self.assertEqual(cached_feature.descendant_count, 3)
+        self.assertEqual(cached_feature.descendant_pks, [])  # Too big to cache
+
+        url = self.api_reverse('viewfeatures-detail', pk=cached_feature.pk)
+        context = self.make_context(url, include_child_pages=True)
+        serializer = ViewFeatureSerializer(context=context)
+        representation = serializer.to_representation(cached_feature)
+        next_page = url + '?child_pages=1&page=2'
+        expected_pagination = {
+            'linked.features': {
+                'previous': None,
+                'next': self.baseUrl + next_page,
+                'count': 3,
+            }
+        }
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_pagination = compat_table['pagination']
         self.assertDataEqual(expected_pagination, actual_pagination)
+
+        context2 = self.make_context(next_page, include_child_pages=True)
+        serializer2 = ViewFeatureSerializer(context=context2)
+        representation = serializer2.to_representation(feature)
+        expected_pagination = {
+            'linked.features': {
+                'previous': self.baseUrl + url + '?child_pages=1&page=1',
+                'next': None,
+                'count': 3,
+            }
+        }
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_pagination = compat_table['pagination']
+        self.assertEqual(expected_pagination, actual_pagination)
 
     @override_settings(PAGINATE_VIEW_FEATURE=2)
     def test_large_feature_tree_html(self):
         feature = self.setup_feature_tree()
         url = self.api_reverse(
             'viewfeatures-detail', pk=feature.pk, format='html')
-        response = self.client.get(url, {'child_pages': True})
+        context = self.make_context(
+            url, include_child_pages=True, format='html')
+        serializer = ViewFeatureSerializer(context=context)
+        representation = serializer.to_representation(feature)
         next_url = self.baseUrl + url + "?child_pages=1&page=2"
-        expected = '<a href="%s">next page</a>' % next_url
-        self.assertContains(response, expected, html=True)
+        expected_pagination = {
+            'linked.features': {
+                'previous': None,
+                'next': next_url,
+                'count': 3,
+            }
+        }
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_pagination = compat_table['pagination']
+        self.assertEqual(expected_pagination, actual_pagination)
+        self.assertTrue('.html' in next_url)
 
     @override_settings(PAGINATE_VIEW_FEATURE=4)
     def test_just_right_feature_tree(self):
         feature = self.setup_feature_tree()
+        self.assertEqual(feature.descendant_count, 3)
         url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url, {'child_pages': True})
-        actual_json = loads(response.content.decode('utf-8'))
+        context = self.make_context(url, include_child_pages=True)
+        serializer = ViewFeatureSerializer(context=context)
+        representation = serializer.to_representation(feature)
         expected_pagination = {
             'linked.features': {
                 'previous': None,
@@ -443,23 +358,8 @@ class TestViewFeatureViewSet(APITestCase):
                 'count': 3,
             }
         }
-        actual_pagination = actual_json['meta']['compat_table']['pagination']
-        self.assertDataEqual(expected_pagination, actual_pagination)
-
-    @override_settings(PAGINATE_VIEW_FEATURE=2)
-    def test_large_feature_tree_no_child_pages_is_unpaginated(self):
-        feature = self.setup_feature_tree()
-        url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url, {'child_pages': '0'})
-        actual_json = loads(response.content.decode('utf-8'))
-        expected_pagination = {
-            'linked.features': {
-                'previous': None,
-                'next': None,
-                'count': 3,
-            }
-        }
-        actual_pagination = actual_json['meta']['compat_table']['pagination']
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_pagination = compat_table['pagination']
         self.assertDataEqual(expected_pagination, actual_pagination)
 
     def test_important_versions(self):
@@ -516,8 +416,9 @@ class TestViewFeatureViewSet(APITestCase):
         s9 = self.create(Support, version=v9, feature=feature, **support)
 
         url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
-        response = self.client.get(url)
-        actual_json = loads(response.content.decode('utf-8'))
+        context = self.make_context(url)
+        serializer = ViewFeatureSerializer(context=context)
+        representation = serializer.to_representation(feature)
         expected_supports = {
             str(feature.pk): {
                 str(browser.pk): [
@@ -525,37 +426,13 @@ class TestViewFeatureViewSet(APITestCase):
                     str(s5.pk), str(s6.pk), str(s7.pk), str(s8.pk),
                     str(s9.pk)
                 ]}}
-        actual_supports = actual_json['meta']['compat_table']['supports']
+        compat_table = representation['_view_extra']['meta']['compat_table']
+        actual_supports = compat_table['supports']
         self.assertDataEqual(expected_supports, actual_supports)
 
-    def test_slug(self):
-        feature = self.create(Feature, slug='feature')
-        browser = self.create(Browser, slug='chrome', name={'en': 'Browser'})
-        version = self.create(Version, browser=browser, status='current')
-        self.create(Support, version=version, feature=feature)
-        self.changeset.closed = True
-        self.changeset.save()
 
-        url = self.api_reverse('viewfeatures-detail', pk='feature')
-        response = self.client.get(url)
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(feature.id, response.data['id'])
-
-    def test_slug_not_found(self):
-        url = self.api_reverse('viewfeatures-detail', pk='feature')
-        response = self.client.get(url)
-        self.assertEqual(404, response.status_code)
-
-    def test_feature_not_found_html(self):
-        self.assertFalse(Feature.objects.filter(id=666).exists())
-        url = self.api_reverse('viewfeatures-detail', pk='666') + '.html'
-        response = self.client.get(url)
-        self.assertEqual(404, response.status_code)
-        self.assertEqual('404 Not Found', response.content.decode('utf8'))
-
-
-class TestViewFeatureUpdates(APITestCase):
-    """Test PUT to a ViewFeature detail"""
+class TestViewFeatureUpdates(TestCase):
+    """Test updating via ViewFeatureSerializer."""
     longMessage = True
 
     def setUp(self):
@@ -574,12 +451,12 @@ class TestViewFeatureUpdates(APITestCase):
         self.browser_data = {
             "id": str(self.browser.id), "slug": self.browser.slug,
             "name": self.browser.name, "note": None,
-            "links": {"versions": [str(self.version.id)]}}
+            "versions": [self.version.id]}
         self.version_data = {
             "id": str(self.version.id), "version": self.version.version,
             "release_day": '2015-02-17', "retirement_day": None, "note": None,
             "status": "unknown", "release_notes_uri": None,
-            "links": {"browser": str(self.browser.id)}}
+            "browser": self.browser.id}
         self.maturity_data = {
             "id": str(self.maturity.id), "slug": self.maturity.slug,
             "name": self.maturity.name}
@@ -587,22 +464,30 @@ class TestViewFeatureUpdates(APITestCase):
             "id": str(self.spec.id), "slug": self.spec.slug,
             "mdn_key": self.spec.mdn_key, "name": self.spec.name,
             "uri": self.spec.uri,
-            "links": {"maturity": str(self.maturity.id), "sections": []}}
+            "maturity": self.maturity.id, "sections": []}
         self.url = self.api_reverse('viewfeatures-detail', pk=self.feature.pk)
+        request = APIRequestFactory().get(self.url)
+        request.version = self.namespace
+        request.versioning_scheme = NamespaceVersioning()
+        request.user = self.user
+        self.context = {'request': request}
+        HistoricalRecords.thread.request = request
 
-    def json_api(self, feature_data=None, meta=None, **resources):
-        base = {'features': {"id": str(self.feature.id)}}
-        if feature_data:
-            base['features'].update(feature_data)
-        if meta:
-            base['meta'] = meta
-        if resources:
-            base['linked'] = {}
-        for name, values in resources.items():
-            base['linked'][name] = values
-        return dumps(base)
+    def assertUpdateSuccess(self, data):
+        feature = Feature.objects.get(id=self.feature.id)  # Clear prop caches
+        serializer = ViewFeatureSerializer(
+            feature, data=data, context=self.context, partial=True)
+        self.assertTrue(serializer.is_valid())
+        return serializer.save()
 
-    def test_post_just_feature(self):
+    def assertUpdateFailed(self, data, expected_errors):
+        feature = Feature.objects.get(id=self.feature.id)  # Clear prop caches
+        serializer = ViewFeatureSerializer(
+            feature, data=data, context=self.context, partial=True)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors, expected_errors)
+
+    def test_just_feature(self):
         data = {
             "mdn_uri": {
                 "en": "https://developer.mozilla.org/en-US/docs/feature",
@@ -613,130 +498,108 @@ class TestViewFeatureUpdates(APITestCase):
                 "fr": "Le Feature",
             }
         }
-        json_data = self.json_api(data)
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
-        f = Feature.objects.get(id=self.feature.id)
-        self.assertEqual(f.mdn_uri, data['mdn_uri'])
-        self.assertEqual(f.name, data['name'])
+        new_feature = self.assertUpdateSuccess(data)
+        self.assertEqual(new_feature.mdn_uri, data['mdn_uri'])
+        self.assertEqual(new_feature.name, data['name'])
 
-    def test_post_add_subfeature(self):
-        subfeature = {
-            "id": "_new", "slug": "subfeature", "name": {"en": "Sub Feature"},
-            "links": {"parent": str(self.feature.pk)}}
-        json_data = self.json_api(features=[subfeature])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+    def test_add_subfeature(self):
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": "subfeature",
+                    "name": {"en": "Sub Feature"},
+                    "parent": self.feature.pk,
+                }],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
         subfeature = Feature.objects.get(slug='subfeature')
-        self.assertEqual(subfeature.parent, self.feature)
-        feature = Feature.objects.get(id=self.feature.id)
-        self.assertEqual(list(feature.children.all()), [subfeature])
-        self.assertEqual(list(feature.get_descendants()), [subfeature])
+        self.assertEqual(subfeature.parent, new_feature)
+        self.assertEqual(list(new_feature.children.all()), [subfeature])
+        self.assertEqual(list(new_feature.get_descendants()), [subfeature])
 
-    def test_post_add_second_subfeature(self):
-        from django.db import connection
-        old_debug = connection.force_debug_cursor
-        connection.force_debug_cursor = True
-        try:
-            sf1 = self.create(
-                Feature, slug='sf1', name={'en': 'sf1'}, parent=self.feature)
-            sf2_data = {
-                "id": "_sf2", "slug": "sf2", "name": {"en": "Sub Feature 2"},
-                "links": {"parent": str(self.feature.pk)}}
-            json_data = self.json_api(
-                feature_data={'links': {'children': [str(sf1.pk), '_sf2']}},
-                features=[sf2_data])
-            response = self.client.put(
-                self.url, data=json_data,
-                content_type="application/vnd.api+json")
-            self.assertEqual(response.status_code, 200, response.content)
-            sf2 = Feature.objects.get(slug='sf2')
-            self.assertEqual(sf2.parent, self.feature)
-            feature = Feature.objects.get(id=self.feature.id)
-            actual = list(feature.children.all())
-            if actual != [sf1, sf2]:  # pragma: nocover
-                # Debug occasional test failure
-                def report(f, prefix='Feature'):
-                    attrs = ['id', 'lft', 'rght', 'tree_id', 'level', 'parent']
-                    return prefix + ': ' + ', '.join(
-                        ['%s=%s' % (a, getattr(f, a)) for a in attrs])
-                msg_lines = [
-                    "=" * 70,
-                    'Unexpected failure in test_post_add_second_subfeature.',
-                    'Report at:',
-                    ' https://bugzilla.mozilla.org/show_bug.cgi?id=1159337',
-                    'DB queries:'
-                ]
-                msg_lines.extend([str(q) for q in connection.queries])
-                msg_lines.extend([
-                    'Features:',
-                    report(self.feature, 'parent'),
-                    report(feature, 'parent from DB'),
-                    report(sf1, 'sf1'),
-                    report(sf2, 'sf2'),
-                    "=" * 70]
-                )
-                print('\n'.join(msg_lines))
-            self.assertEqual(list(feature.children.all()), [sf1, sf2])
-        finally:
-            connection.force_debug_cursor = old_debug
+    def test_add_second_subfeature(self):
+        sf1 = self.create(
+            Feature, slug='sf1', name={'en': 'sf1'}, parent=self.feature)
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_sf2",
+                    "slug": "sf2",
+                    "name": {"en": "Sub Feature 2"},
+                    "parent": self.feature.pk,
+                }],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
+        sf2 = Feature.objects.get(slug='sf2')
+        self.assertEqual(sf2.parent, new_feature)
+        self.assertEqual(list(new_feature.children.all()), [sf1, sf2])
 
-    def test_post_add_second_subfeature_with_existing_support(self):
+    def test_add_second_subfeature_with_existing_support(self):
         detail1 = self.create(
             Feature, slug='detail1', name={'en': 'Detail 1'},
             parent=self.feature)
         self.create(Support, version=self.version, feature=detail1)
-        detail2_data = {
-            "id": "_detail2", "slug": "detail2",
-            "name": {"en": "Detail 2"},
-            "links": {"parent": str(self.feature.pk)}}
-        json_data = self.json_api(features=[detail2_data])
-        response = self.client.put(
-            self.url, data=json_data,
-            content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_detail2",
+                    "slug": "detail2",
+                    "name": {"en": "Detail 2"},
+                    "parent": self.feature.pk
+                }],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
         detail2 = Feature.objects.get(slug='detail2')
-        self.assertEqual(detail2.parent, self.feature)
-        feature = Feature.objects.get(id=self.feature.id)
-        self.assertEqual(list(feature.children.all()), [detail1, detail2])
+        self.assertEqual(detail2.parent, new_feature)
+        self.assertEqual(list(new_feature.children.all()), [detail1, detail2])
 
-    def test_post_update_existing_subfeature(self):
+    def test_update_existing_subfeature(self):
         subfeature = self.create(
             Feature, slug='subfeature', name={'en': 'subfeature'},
             parent=self.feature)
-        subfeature_data = {
-            "id": str(subfeature.id), "slug": "subfeature",
-            "name": {"en": "subfeature 1"},
-            "links": {"parent": str(self.feature.pk)}}
-        json_data = self.json_api(
-            feature_data={'links': {'children': [str(subfeature.pk)]}},
-            features=[subfeature_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
-        subfeature = Feature.objects.get(id=subfeature.id)
-        self.assertEqual(subfeature.parent, self.feature)
-        self.assertEqual(subfeature.name, {"en": "subfeature 1"})
-        feature = Feature.objects.get(id=self.feature.id)
-        self.assertEqual(list(feature.children.all()), [subfeature])
+        data = {
+            'children': [subfeature.pk],
+            '_view_extra': {
+                'features': [{
+                    "id": subfeature.id,
+                    "slug": "subfeature",
+                    "name": {"en": "subfeature 1"},
+                    "parent": self.feature.pk,
+                }],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
+        new_subfeature = Feature.objects.get(id=subfeature.id)
+        self.assertEqual(new_subfeature.parent, self.feature)
+        self.assertEqual(new_subfeature.name, {"en": "subfeature 1"})
+        self.assertEqual(list(new_feature.children.all()), [new_subfeature])
 
-    def test_post_add_subsupport(self):
-        subfeature_data = {
-            "id": "_new", "slug": "subfeature", "name": {"en": "Sub Feature"},
-            "links": {"parent": str(self.feature.pk)}}
-        support_data = {
-            "id": "_new_yes", "support": "yes",
-            "links": {"version": str(self.version.id), "feature": "_new"}}
-        json_data = self.json_api(
-            features=[subfeature_data], supports=[support_data],
-            versions=[self.version_data], browsers=[self.browser_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+    def test_add_subsupport(self):
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": "subfeature",
+                    "name": {"en": "Sub Feature"},
+                    "parent": self.feature.pk,
+                }],
+                'supports': [{
+                    "id": "_new_yes",
+                    "support": "yes",
+                    "version": self.version.id,
+                    "feature": "_new",
+                }],
+                'browsers': [self.browser_data],
+                'versions': [self.version_data],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
         subfeature = Feature.objects.get(slug='subfeature')
-        self.assertEqual(subfeature.parent, self.feature)
+        self.assertEqual(subfeature.parent, new_feature)
         self.assertEqual(subfeature.name, {"en": "Sub Feature"})
         supports = subfeature.supports.all()
         self.assertEqual(1, len(supports))
@@ -744,127 +607,139 @@ class TestViewFeatureUpdates(APITestCase):
         self.assertEqual(support.version, self.version)
         self.assertEqual('yes', support.support)
 
-    def test_post_no_change(self):
+    def test_no_change_no_id(self):
         subfeature = self.create(
             Feature, slug='subfeature', name={'en': 'subfeature'},
             parent=self.feature)
         history_count = subfeature.history.all().count()
-        subfeature_data = {
-            'slug': 'subfeature', 'mdn_uri': None,
-            'experimental': False, 'standardized': True, 'stable': True,
-            'obsolete': False, 'name': {'en': 'subfeature'},
-            'links': {
-                'parent': str(self.feature.id),
-                'sections': [],
-                'children': []}}
-        json_data = self.json_api(
-            features=[subfeature_data], meta={'not': 'used'})
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+        data = {
+            '_view_extra': {
+                'features': [{
+                    'slug': 'subfeature',
+                    'mdn_uri': None,
+                    'experimental': False,
+                    'standardized': True,
+                    'stable': True,
+                    'obsolete': False,
+                    'name': {'en': 'subfeature'},
+                    'parent': self.feature.id,
+                    'sections': [],
+                    'children': [],
+                }],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
         subfeature = Feature.objects.get(slug='subfeature')
-        self.assertEqual(subfeature.parent, self.feature)
+        self.assertEqual(subfeature.parent, new_feature)
         self.assertEqual(subfeature.name, {"en": "subfeature"})
         self.assertEqual(history_count, subfeature.history.all().count())
 
-    def test_existing_changeset(self):
-        response = self.client.post(
-            self.api_reverse('changeset-list'), dumps({}),
-            content_type="application/vnd.api+json")
-        self.assertEqual(201, response.status_code, response.content)
-        response_json = loads(response.content.decode('utf-8'))
-        changeset_id = response_json['changesets']['id']
-        c = '?changeset=%s' % changeset_id
-
-        subfeature = {
-            "id": "_new", "slug": "subfeature", "name": {"en": "Sub Feature"},
-            "links": {"parent": str(self.feature.pk)}}
-        json_data = self.json_api(features=[subfeature])
-        response = self.client.put(
-            self.url + c, data=json_data,
-            content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+    def test_changeset_is_applied_to_items(self):
+        changeset = self.create(Changeset, closed=False, user=self.user)
+        self.context['request'].changeset = changeset
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": "subfeature",
+                    "name": {"en": "Sub Feature"},
+                    "parent": self.feature.pk,
+                }],
+            },
+        }
+        new_feature = self.assertUpdateSuccess(data)
         subfeature = Feature.objects.get(slug='subfeature')
-        self.assertEqual(subfeature.parent, self.feature)
+        self.assertEqual(subfeature.parent, new_feature)
         self.assertEqual(
-            int(changeset_id),
+            changeset.id,
             subfeature.history.last().history_changeset_id)
-
-        close = {'changesets': {'id': changeset_id, 'close': True}}
-        response = self.client.post(
-            self.api_reverse('changeset-detail', pk=changeset_id),
-            dumps(close), content_type="application/vnd.api+json")
+        changeset.closed = True
+        changeset.save()
 
     def test_invalid_subfeature(self):
-        subfeature = {
-            "id": "_new", "slug": None, "name": {"en": "Sub Feature"},
-            "links": {"parent": str(self.feature.pk)}}
-        json_data = self.json_api(features=[subfeature])
-        response = self.client.put(
-            self.url, data=json_data,
-            content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.features.0.slug",
-                "detail": "This field may not be null.",
-            }]
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": None,
+                    "name": {"en": "Sub Feature"},
+                    "parent": self.feature.pk,
+                }],
+            },
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
+        expected_errors = {
+            '_view_extra': {
+                'features': {
+                    0: {
+                        'slug': ["This field may not be null."],
+                    },
+                },
+            }
+        }
+        self.assertUpdateFailed(data, expected_errors)
 
     def test_invalid_support(self):
-        subfeature_data = {
-            "id": "_new", "slug": "subfeature", "name": {"en": "Sub Feature"},
-            "links": {"parent": str(self.feature.pk)}}
-        support_data = {
-            "id": "_new_maybe", "support": "maybe",
-            "links": {"version": str(self.version.id), "feature": "_new"}}
-        json_data = self.json_api(
-            features=[subfeature_data], supports=[support_data],
-            versions=[self.version_data], browsers=[self.browser_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.supports.0.support",
-                "detail": '"maybe" is not a valid choice.',
-            }]
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": "subfeature",
+                    "name": {"en": "Sub Feature"},
+                    "parent": self.feature.pk,
+                }],
+                'supports': [{
+                    "id": "_new_maybe",
+                    "support": "maybe",
+                    "version": self.version.id,
+                    "feature": "_new",
+                }],
+                'browsers': [self.browser_data],
+                'versions': [self.version_data],
+            },
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
-        self.assertFalse(Feature.objects.filter(slug='subfeature').exists())
+        expected_errors = {
+            '_view_extra': {
+                'supports': {
+                    0: {
+                        'support': ['"maybe" is not a valid choice.'],
+                    },
+                }
+            }
+        }
+        self.assertUpdateFailed(data, expected_errors)
 
     def test_add_section(self):
-        section_data = {
-            "id": "_section", "name": {"en": "Section"},
-            "links": {
-                "specification": str(self.spec.id),
-                "features": [str(self.feature.id)],
-            }}
-        json_data = self.json_api(
-            {'sections': ['_section']}, sections=[section_data],
-            specifications=[self.spec_data], maturities=[self.maturity_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+        data = {
+            'sections': ['_section'],
+            '_view_extra': {
+                'sections': [{
+                    "id": "_section",
+                    "name": {"en": "Section"},
+                    "specification": self.spec.id,
+                    "features": [self.feature.id],
+                }],
+                'specifications': [self.spec_data],
+                'maturities': [self.maturity_data],
+            }
+        }
+        new_feature = self.assertUpdateSuccess(data)
         section = Section.objects.get()
-        self.assertEqual([self.feature], list(section.features.all()))
+        self.assertEqual([new_feature], list(section.features.all()))
 
     def test_add_support_to_target(self):
-        support_data = {
-            "id": "_yes", "support": "yes",
-            "links": {
-                "version": str(self.version.id),
-                "feature": str(self.feature.id),
-            }}
-        json_data = self.json_api(
-            supports=[support_data], versions=[self.version_data],
-            browsers=[self.browser_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 200, response.content)
+        data = {
+            '_view_extra': {
+                'supports': [{
+                    "id": "_yes",
+                    "support": "yes",
+                    "version": self.version.id,
+                    "feature": self.feature.id,
+                }],
+                'versions': [self.version_data],
+                'browsers': [self.browser_data],
+            }
+        }
+        self.assertUpdateSuccess(data)
         support = Support.objects.get()
         self.assertEqual(self.version, support.version)
         self.assertEqual(self.feature, support.feature)
@@ -875,127 +750,155 @@ class TestViewFeatureUpdates(APITestCase):
         self.assertIsNone(ViewFeatureExtraSerializer().to_representation(None))
 
     def test_top_level_feature_is_error(self):
-        subfeature = {
-            "id": "_new", "slug": 'slug', "name": {"en": "Sub Feature"},
-            "links": {"parent": None}}
-        json_data = self.json_api(features=[subfeature])
-        response = self.client.put(
-            self.url, data=json_data,
-            content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.features.0.parent",
-                "detail": (
-                    "Feature must be a descendant of feature %s." %
-                    self.feature.id),
-            }]
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": 'slug',
+                    "name": {"en": "Sub Feature"},
+                    "parent": None,
+                }]
+            }
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
+        err_msg = (
+            "Feature must be a descendant of feature %s." % self.feature.id)
+        expected_errors = {
+            '_view_extra': {
+                'features': {
+                    0: {'parent': [err_msg]},
+                }
+            }
+        }
+        self.assertUpdateFailed(data, expected_errors)
 
     def test_other_feature_is_error(self):
         other = self.create(
             Feature, slug='other', name={'en': "Other"})
-        subfeature = {
-            "id": "_new", "slug": 'slug', "name": {"en": "Sub Feature"},
-            "links": {"parent": str(other.id)}}
-        json_data = self.json_api(features=[subfeature])
-        response = self.client.put(
-            self.url, data=json_data,
-            content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.features.0.parent",
-                "detail": (
-                    "Feature must be a descendant of feature %s." %
-                    self.feature.id),
-            }]
+        data = {
+            '_view_extra': {
+                'features': [{
+                    "id": "_new",
+                    "slug": 'slug',
+                    "name": {"en": "Sub Feature"},
+                    "parent": other.id
+                }]
+            },
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
-
-    def test_changed_maturity_is_error(self):
-        section_data = {
-            "id": "_section", "name": {"en": "Section"},
-            "links": {
-                "specification": str(self.spec.id),
-                "features": [str(self.feature.id)],
+        err_msg = (
+            "Feature must be a descendant of feature %s." % self.feature.id)
+        expected_errors = {
+            '_view_extra': {
+                'features': {
+                    0: {'parent': [err_msg]},
+                }
             }
         }
+        self.assertUpdateFailed(data, expected_errors)
+
+    def test_changed_maturity_is_error(self):
         maturity_data = self.maturity_data.copy()
         maturity_data['name']['en'] = "New Maturity Name"
-        json_data = self.json_api(
-            {'sections': ['_section']}, sections=[section_data],
-            specifications=[self.spec_data], maturities=[maturity_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.maturities.0.name",
-                "detail": (
-                    'Field can not be changed from {"en": "Mature"} to'
-                    ' {"en": "New Maturity Name"} as part of this update.'
-                    ' Update the resource by itself, and try again.'),
-            }]
+        data = {
+            'sections': ['_section'],
+            '_view_extra': {
+                'sections': [{
+                    "id": "_section",
+                    "name": {"en": "Section"},
+                    "specification": self.spec.id,
+                    "features": [self.feature.id],
+                }],
+                'specifications': [self.spec_data],
+                'maturities': [maturity_data],
+            }
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
+        err_msg = (
+            'Field can not be changed from {"en": "Mature"} to'
+            ' {"en": "New Maturity Name"} as part of this update. Update the'
+            ' resource by itself, and try again.')
+        expected_errors = {
+            '_view_extra': {
+                'maturities': {
+                    0: {'name': [err_msg]},
+                }
+            }
+        }
+        self.assertUpdateFailed(data, expected_errors)
 
     def test_new_specification_is_error(self):
-        section_data = {
-            "id": "_section", "name": {"en": "Section"},
-            "links": {
-                "specification": "_NEW", "features": [str(self.feature.id)]}}
-        spec_data = {
-            "id": "_NEW", "slug": "NEW", "mdn_key": "",
-            "name": {"en": "New Specification"},
-            "uri": {"en": "https://example.com/new"},
-            "links": {"maturity": str(self.maturity.id)}}
-        json_data = self.json_api(
-            {'sections': ['_section']}, sections=[section_data],
-            specifications=[spec_data], maturities=[self.maturity_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.specifications.0.id",
-                "detail": (
-                    'Resource can not be created as part of this update.'
-                    ' Create first, and try again.'),
-            }]
+        data = {
+            'sections': ['_section'],
+            '_view_extra': {
+                'sections': [{
+                    "id": "_section",
+                    "name": {"en": "Section"},
+                    "specification": "_NEW",
+                    "features": [self.feature.id],
+                }],
+                'specifications': [{
+                    "id": "_NEW",
+                    "slug": "NEW",
+                    "mdn_key": "",
+                    "name": {"en": "New Specification"},
+                    "uri": {"en": "https://example.com/new"},
+                    "maturity": self.maturity.id,
+                }],
+                'maturities': [self.maturity_data],
+            }
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
+        err_msg = (
+            'Resource can not be created as part of this update. Create'
+            ' first, and try again.')
+        expected_errors = {
+            '_view_extra': {
+                'specifications': {
+                    0: {'id': [err_msg]},
+                }
+            }
+        }
+        self.assertUpdateFailed(data, expected_errors)
 
     def test_new_version_is_error(self):
-        support_data = {
-            "id": "_yes", "support": "yes",
-            "links": {
-                "version": "_NEW", "feature": str(self.feature.id),
-            }}
-        version_data = {
-            "id": "_NEW", "version": "1.0", "note": None,
-            "links": {"browser": str(self.browser.id)}}
-        json_data = self.json_api(
-            supports=[support_data], versions=[version_data],
-            browsers=[self.browser_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.versions.0.id",
-                "detail": (
-                    'Resource can not be created as part of this update.'
-                    ' Create first, and try again.'),
-            }]
+        data = {
+            '_view_extra': {
+                'supports': [{
+                    "id": "_yes",
+                    "support": "yes",
+                    "version": "_NEW",
+                    "feature": self.feature.id,
+                }],
+                'versions': [{
+                    "id": "_NEW",
+                    "version": "1.0",
+                    "note": None,
+                    "browser": self.browser.id,
+                }],
+                'browsers': [self.browser_data],
+            }
         }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
+        err_msg = (
+            'Resource can not be created as part of this update. Create'
+            ' first, and try again.')
+        expected_errors = {
+            '_view_extra': {
+                'versions': {
+                    0: {'id': [err_msg]}
+                }
+            }
+        }
+        self.assertUpdateFailed(data, expected_errors)
+
+    def test_unknown_resource_ignored(self):
+        data = {
+            'name': {'en': 'New Name'},
+            '_view_extra': {
+                'unknown': [{
+                    "id": "_new",
+                    "foo": "bar",
+                }],
+            }
+        }
+        new_feature = self.assertUpdateSuccess(data)
+        self.assertEqual(new_feature.name, {'en': 'New Name'})
 
 
 class TestDjangoResourceClient(TestCase):

--- a/webplatformcompat/tests/test_view_serializers.py
+++ b/webplatformcompat/tests/test_view_serializers.py
@@ -446,6 +446,22 @@ class TestViewFeatureViewSet(APITestCase):
         actual_pagination = actual_json['meta']['compat_table']['pagination']
         self.assertDataEqual(expected_pagination, actual_pagination)
 
+    @override_settings(PAGINATE_VIEW_FEATURE=2)
+    def test_large_feature_tree_no_child_pages_is_unpaginated(self):
+        feature = self.setup_feature_tree()
+        url = self.api_reverse('viewfeatures-detail', pk=feature.pk)
+        response = self.client.get(url, {'child_pages': '0'})
+        actual_json = loads(response.content.decode('utf-8'))
+        expected_pagination = {
+            'linked.features': {
+                'previous': None,
+                'next': None,
+                'count': 3,
+            }
+        }
+        actual_pagination = actual_json['meta']['compat_table']['pagination']
+        self.assertDataEqual(expected_pagination, actual_pagination)
+
     def test_important_versions(self):
         feature = self.create(Feature, slug='feature')
         browser = self.create(Browser, slug='browser')

--- a/webplatformcompat/tests/test_views.py
+++ b/webplatformcompat/tests/test_views.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Tests for `web-platform-compat` views module."""
+"""Tests for the API views."""
 from json import loads
 
 from django.core.urlresolvers import reverse

--- a/webplatformcompat/tests/test_viewsets.py
+++ b/webplatformcompat/tests/test_viewsets.py
@@ -6,11 +6,19 @@ from datetime import datetime
 from json import dumps, loads
 from pytz import UTC
 
+from django.http import Http404
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 import mock
 
 from webplatformcompat.history import Changeset
 from webplatformcompat.models import (
     Browser, Feature, Maturity, Section, Specification, Support, Version)
+from webplatformcompat.view_serializers import (
+    ViewFeatureListSerializer, ViewFeatureRowChildrenSerializer,
+    ViewFeatureSerializer)
+
+from webplatformcompat.viewsets import ViewFeaturesViewSet
 from .base import APITestCase
 
 
@@ -426,3 +434,75 @@ class TestHistoricaViewset(APITestCase):
         }
         actual_json = loads(response.content.decode('utf-8'))
         self.assertDataEqual(expected_json, actual_json)
+
+
+class TestViewFeatureViewset(APITestCase):
+
+    def setUp(self):
+        self.queryset = Feature.objects.all()
+        self.view = ViewFeaturesViewSet()
+
+    def test_serializer_for_list(self):
+        self.view.action = 'list'
+        serializer_cls = self.view.get_serializer_class()
+        self.assertEqual(serializer_cls, ViewFeatureListSerializer)
+
+    def test_serializer_for_child_pages(self):
+        self.view.action = 'retrieve'
+        url = self.api_reverse('viewfeatures-detail', pk=1)
+        request = APIRequestFactory().get(url, {'child_pages': '1'})
+        self.view.request = Request(request)
+        serializer_cls = self.view.get_serializer_class()
+        self.assertEqual(serializer_cls, ViewFeatureSerializer)
+
+    def test_serializer_for_rows_only(self):
+        self.view.action = 'retrieve'
+        url = self.api_reverse('viewfeatures-detail', pk=1)
+        request = APIRequestFactory().get(url, {'child_pages': '0'})
+        self.view.request = Request(request)
+        serializer_cls = self.view.get_serializer_class()
+        self.assertEqual(serializer_cls, ViewFeatureRowChildrenSerializer)
+
+    def test_serializer_for_updates(self):
+        self.view.action = 'partial_update'
+        url = self.api_reverse('viewfeatures-detail', pk=1)
+        request = APIRequestFactory().get(url, {'child_pages': '1'})
+        self.view.request = Request(request)
+        serializer_cls = self.view.get_serializer_class()
+        self.assertEqual(serializer_cls, ViewFeatureSerializer)
+
+    def test_get_by_id(self):
+        parent = self.create(Feature, slug='parent')
+        feature = self.create(Feature, slug='feature', parent=parent)
+        ret = self.view.get_object_or_404(self.queryset, pk=feature.pk)
+        self.assertEqual(ret.pk, feature.pk)
+        with self.assertNumQueries(0):
+            self.assertEqual(ret.parent_id, parent.id)
+
+    def test_get_by_slug(self):
+        feature = self.create(Feature, slug='feature')
+        ret = self.view.get_object_or_404(self.queryset, pk=feature.slug)
+        self.assertEqual(ret.pk, feature.pk)
+        with self.assertNumQueries(0):
+            self.assertIsNone(ret.parent_id)
+
+    def test_get_by_slug_not_found(self):
+        self.assertFalse(self.queryset.filter(slug='feature').exists())
+        self.assertRaises(
+            Http404, self.view.get_object_or_404, self.queryset, pk='feature')
+
+    def test_feature_found_html(self):
+        parent = self.create(Feature, slug='parent')
+        feature = self.create(Feature, slug='feature', parent=parent)
+        self.create(Feature, slug='child', parent=feature)
+        url = self.api_reverse(
+            'viewfeatures-detail', pk=feature.pk, format='html')
+        response = self.client.get(url)
+        self.assertContains(response, '<h2>Browser compatibility</h2>')
+
+    def test_feature_not_found_html(self):
+        self.assertFalse(Feature.objects.filter(id=666).exists())
+        url = self.api_reverse('viewfeatures-detail', pk='666') + '.html'
+        response = self.client.get(url)
+        self.assertEqual(404, response.status_code)
+        self.assertEqual('404 Not Found', response.content.decode('utf8'))

--- a/webplatformcompat/tests/test_viewsets.py
+++ b/webplatformcompat/tests/test_viewsets.py
@@ -282,6 +282,15 @@ class TestGenericViewset(APITestCase):
         self.assertEqual(204, response.status_code, response.content)
         self.assertFalse(Browser.objects.filter(pk=browser.pk).exists())
 
+    def test_options(self):
+        self.login_user()
+        browser = self.create(Browser)
+        url = self.api_reverse('browser-detail', pk=browser.pk)
+        response = self.client.options(url)
+        self.assertEqual(200, response.status_code, response.content)
+        expected_keys = {'actions', 'description', 'name', 'parses', 'renders'}
+        self.assertEqual(set(response.data.keys()), expected_keys)
+
 
 class TestCascadeDelete(APITestCase):
     def setUp(self):

--- a/webplatformcompat/tests/test_viewsets.py
+++ b/webplatformcompat/tests/test_viewsets.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Tests for `web-platform-compat.viewsets."""
+"""Tests for API viewsets."""
 from __future__ import unicode_literals
 from datetime import datetime
 from json import dumps, loads
@@ -22,7 +21,7 @@ from webplatformcompat.viewsets import ViewFeaturesViewSet
 from .base import APITestCase
 
 
-class TestGenericViewset(APITestCase):
+class TestBrowserViewset(APITestCase):
     """Test common viewset functionality through the browsers viewset."""
 
     def test_get_browser_detail(self):

--- a/webplatformcompat/urls.py
+++ b/webplatformcompat/urls.py
@@ -1,3 +1,4 @@
+"""URLs for API and sample views."""
 from django.conf.urls import include, patterns, url
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView

--- a/webplatformcompat/urls.py
+++ b/webplatformcompat/urls.py
@@ -1,20 +1,21 @@
 from django.conf.urls import include, patterns, url
+from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 from mdn.urls import mdn_urlpatterns
 from webplatformcompat.routers import router
 
-from .views import RequestView, ViewFeature
+from .views import ViewFeature
 
 
 webplatformcompat_urlpatterns = patterns(
     '',
-    url(r'^$', RequestView.as_view(
+    url(r'^$', TemplateView.as_view(
         template_name='webplatformcompat/home.html'),
         name='home'),
-    url(r'^about/', RequestView.as_view(
+    url(r'^about/', TemplateView.as_view(
         template_name='webplatformcompat/about.html'),
         name='about'),
-    url(r'^browse/', RequestView.as_view(
+    url(r'^browse/', TemplateView.as_view(
         template_name='webplatformcompat/browse.html'),
         name='browse'),
     url(r'^api-auth/', include('rest_framework.urls',

--- a/webplatformcompat/view_serializers.py
+++ b/webplatformcompat/view_serializers.py
@@ -414,7 +414,7 @@ class ViewFeatureExtraSerializer(ModelSerializer):
         """Add the sources used by the serializer fields."""
         page = self.context['request'].GET.get('page', 1)
         per_page = settings.PAGINATE_VIEW_FEATURE
-        if self.context['include_child_pages']:
+        if self.context.get('include_child_pages'):
             # Paginate the full descendant tree
             child_queryset = self.get_all_descendants(obj, per_page)
             paginated_child_features = Paginator(child_queryset, per_page)
@@ -692,12 +692,12 @@ class ViewFeatureExtraSerializer(ModelSerializer):
             ('previous', None),
             ('next', None),
         ))
-        if self.context['include_child_pages']:
+        if self.context.get('include_child_pages'):
             # When full descendant list, use pagination
             # The list can get huge when asking for root features like web-css
             pagination['count'] = obj.descendant_count
             url_kwargs = {'pk': obj.id}
-            if self.context['format']:
+            if self.context.get('format'):
                 url_kwargs['format'] = self.context['format']
             request = self.context['request']
             url = reverse(
@@ -735,7 +735,7 @@ class ViewFeatureExtraSerializer(ModelSerializer):
         """Assemble the metadata for the feature view."""
         significant_changes = self.significant_changes(obj)
         browser_tabs = self.browser_tabs(obj)
-        include_child_pages = self.context['include_child_pages']
+        include_child_pages = self.context.get('include_child_pages', False)
         pagination = self.pagination(obj)
         languages = self.find_languages(obj)
         notes = self.ordered_notes(

--- a/webplatformcompat/view_serializers.py
+++ b/webplatformcompat/view_serializers.py
@@ -21,7 +21,14 @@ from .models import (
 from .serializers import (
     BrowserSerializer, FieldMapMixin, FeatureSerializer, MaturitySerializer,
     SectionSerializer, SpecificationSerializer, SupportSerializer,
-    VersionSerializer, omit_some)
+    VersionSerializer)
+
+
+def omit_some(source_list, *omitted):
+    """Return a list with some items omitted"""
+    for item in omitted:
+        assert item in source_list, '%r not in %r' % (item, source_list)
+    return [x for x in source_list if x not in omitted]
 
 
 class ViewBrowserSerializer(BrowserSerializer):

--- a/webplatformcompat/view_serializers.py
+++ b/webplatformcompat/view_serializers.py
@@ -24,38 +24,50 @@ from .serializers import (
     VersionSerializer, FieldsExtraMixin)
 
 
-def omit_some(source_list, *omitted):
-    """Return a list with some items omitted"""
-    for item in omitted:
-        assert item in source_list, '%r not in %r' % (item, source_list)
-    return [x for x in source_list if x not in omitted]
-
+#
+# View-specific serializers
+# Data flows from supports out (feature->version->browser,
+# section->specification->maturity), so omit the "reverse" relations
+# (browser.versions, specification.sections) to reduce size of response.
+#
 
 class ViewBrowserSerializer(BrowserSerializer):
     class Meta(BrowserSerializer.Meta):
-        fields = omit_some(BrowserSerializer.Meta.fields, 'versions')
+        # Omit versions
+        fields = (
+            'id', 'slug', 'name', 'note', 'history_current', 'history')
 
 
 class ViewMaturitySerializer(MaturitySerializer):
     class Meta(MaturitySerializer.Meta):
-        fields = omit_some(MaturitySerializer.Meta.fields, 'specifications')
+        # Omit specifications
+        fields = ('id', 'slug', 'name', 'history_current', 'history')
 
 
 class ViewSectionSerializer(SectionSerializer):
     class Meta(SectionSerializer.Meta):
-        fields = omit_some(SectionSerializer.Meta.fields, 'features')
+        # Omit features
+        fields = (
+            'id', 'number', 'name', 'subpath', 'note', 'specification',
+            'history_current', 'history')
 
 
 class ViewSpecificationSerializer(SpecificationSerializer):
     class Meta(SpecificationSerializer.Meta):
-        fields = omit_some(SpecificationSerializer.Meta.fields, 'sections')
+        # Omit sections
+        fields = (
+            'id', 'slug', 'mdn_key', 'name', 'uri', 'maturity',
+            'history_current', 'history')
 
 
 class ViewVersionSerializer(VersionSerializer):
     class Meta(VersionSerializer.Meta):
-        fields = omit_some(VersionSerializer.Meta.fields, 'supports')
-        read_only_fields = omit_some(
-            VersionSerializer.Meta.read_only_fields, 'supports')
+        # Omit supports
+        fields = (
+            'id', 'version', 'release_day', 'retirement_day',
+            'status', 'release_notes_uri', 'note', 'order', 'browser',
+            'history_current', 'history')
+        read_only_fields = []
 
 
 # Map resource names to model, view serializer classes

--- a/webplatformcompat/views.py
+++ b/webplatformcompat/views.py
@@ -1,20 +1,9 @@
 from django.views.generic import TemplateView
 
 
-class RequestContextMixin(object):
-    def get_context_data(self, **kwargs):
-        ctx = super(RequestContextMixin, self).get_context_data(**kwargs)
-        ctx['request'] = self.request
-        return ctx
-
-
-class RequestView(RequestContextMixin, TemplateView):
-    pass
-
-
-class ViewFeature(RequestContextMixin, TemplateView):
+class ViewFeature(TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super(ViewFeature, self).get_context_data(**kwargs)
-        ctx['feature_id'] = self.kwargs['feature_id']
+        ctx['feature_id'] = kwargs['feature_id']
         return ctx

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -243,7 +243,7 @@ class ViewFeaturesViewSet(UpdateOnlyModelViewSet):
         request = getattr(self, 'request')
         child_pages = request and request.query_params.get('child_pages')
         falsy = ('0', 'false', 'no')
-        return bool(child_pages and child_pages.lower not in falsy)
+        return bool(child_pages and child_pages.lower() not in falsy)
 
     def get_object_or_404(self, queryset, *filter_args, **filter_kwargs):
         """The feature can be accessed by primary key or by feature slug."""

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -78,17 +78,20 @@ class FieldsExtraMixin(object):
 
 class ModelViewSet(
         PartialPutMixin, CachedViewMixin, FieldsExtraMixin, BaseModelViewSet):
+    """Base class for ViewSets supporting CRUD operations on models."""
     renderer_classes = (JsonApiRC1Renderer, BrowsableAPIRenderer)
     parser_classes = (JsonApiRC1Parser, FormParser, MultiPartParser)
 
 
 class ReadOnlyModelViewSet(FieldsExtraMixin, BaseROModelViewSet):
+    """Base class for ViewSets supporting read operations on models."""
     renderer_classes = (JsonApiRC1Renderer, BrowsableAPIRenderer)
 
 
-class UpdateOnlyModelViewSet(
-        PartialPutMixin, CachedViewMixin, UpdateModelMixin,
-        ReadOnlyModelViewSet):
+class ReadUpdateModelViewSet(
+        PartialPutMixin, CachedViewMixin, FieldsExtraMixin, UpdateModelMixin,
+        BaseROModelViewSet):
+    """Base class for ViewSets supporting read and update operations."""
     renderer_classes = (JsonApiRC1Renderer, BrowsableAPIRenderer)
     parser_classes = (JsonApiRC1Parser, FormParser, MultiPartParser)
 
@@ -211,7 +214,7 @@ class HistoricalVersionViewSet(ReadOnlyModelViewSet):
 # Views
 #
 
-class ViewFeaturesViewSet(UpdateOnlyModelViewSet):
+class ViewFeaturesViewSet(ReadUpdateModelViewSet):
     queryset = Feature.objects.order_by('id')
     filter_fields = ('slug',)
     parser_classes = (JsonApiRC1Parser, FormParser, MultiPartParser)

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -240,13 +240,43 @@ class ViewFeaturesViewSet(ReadUpdateModelViewSet):
 
     @cached_property
     def include_child_pages(self):
-        """Return True if the response should include paginated child pages."""
+        """Return True if the response should include paginated child pages.
+
+        The default is exclude paginated child pages, and only include row
+        children that detail the subject feature.  This matches the
+        expectations of most writers - the table on:
+
+        /Web/JavaScript/Reference/Global_Objects/Object
+
+        should only include a "Basic Support" row, not the 30+ pages under
+        Object, such as:
+
+        /Web/JavaScript/Reference/Global_Objects/Object/toString
+
+        However, if they do want a table summarizing the entire page
+        heirarchy, they can add a query parameter such as:
+
+        ?child_pages=1
+
+        These (and variants with capital letters) are synonyms for the default
+        of excluding paginated child pages:
+
+        ?child_pages=0
+        ?child_pages=false
+        ?child_pages=no
+        ?child_pages=NO
+
+        and anything else will include them:
+
+        ?child_pages
+        ?child_pages=yes
+        ?child_pages=Please%20let%20me%20have%20them
+        """
         if self.action != 'retrieve':
             return True
-        request = getattr(self, 'request')
-        child_pages = request and request.query_params.get('child_pages')
+        child_pages = self.request.query_params.get('child_pages', '0')
         falsy = ('0', 'false', 'no')
-        return bool(child_pages and child_pages.lower() not in falsy)
+        return bool(child_pages.lower() not in falsy)
 
     def get_object_or_404(self, queryset, *filter_args, **filter_kwargs):
         """The feature can be accessed by primary key or by feature slug."""


### PR DESCRIPTION
Lots of changes in preparation to support v1/v2 API in same code base (see https://github.com/mdn/browsercompat/tree/spike4_v2_api_1159406 to see what v2 looks like):

* Move DRF serializer additions to a fields_extra property
* Rewrite JSON API RC1 parser and renderer w/o external library
* Improve cached relations on FeatureSerializer
* Fix some issues seen during testing