### PR TITLE
bug 1218237, others - Refactor and expand settings

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -50,11 +50,47 @@ EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
 # DEFAULT_FROM_EMAIL="webmaster@localhost"
 
 #
-# Less common config
+# Security Settings, including SecurityMiddleware
+# https://docs.djangoproject.com/en/1.9/ref/middleware/#django.middleware.security.SecurityMiddleware
 #
 
 # Comma-separated list of allowed hosts, used in non-debug mode
 # ALLOWED_HOSTS="adj-noun.herokoapp.com,adj-noun.co"
+
+# Enable SSL-at-the-proxy
+# SECURE_PROXY_SSL_HEADER="HTTP_X_FORWARDED_PROTOCOL,https"
+
+# Enable HTTP Strict Transport Security (HSTS) for whole domain
+# SECURE_HSTS_SECONDS=3600  # One hour
+
+# Enable HSTS for subdomains as well
+# SECURE_HSTS_INCLUDE_SUBDOMAINS=1
+
+# Add header X-Content-Type-Options: nosniff
+# SECURE_CONTENT_TYPE_NOSNIFF=1
+
+# Add header X-XSS-Protection: 1; mode=block
+# SECURE_BROWSER_XSS_FILTER=1
+
+# Redirect HTTP connections to HTTPS in Django
+# SECURE_SSL_REDIRECT=1
+
+# Only send session cookies on HTTPS connections
+# SESSION_COOKIE_SECURE=1
+
+# Only send CSRF cookies on HTTPS connections
+# CSRF_COOKIE_SECURE=1
+
+# Add HttpOnly flag to CSRF cookie, to prevent in-page JS from accessing
+# CSRF_COOKIE_HTTPONLY=1
+
+# Disallow loading in an iframe, to prevent clickjacking
+# https://docs.djangoproject.com/en/1.9/ref/clickjacking/
+# X_FRAME_OPTIONS = 'DENY'
+
+#
+# Less common config
+#
 
 # Comma-separated list of extra apps to add to INSTALLED_APPS
 # EXTRA_INSTALLED_APPS="gunicorn"
@@ -76,9 +112,6 @@ EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
 
 # Choose eventual consistency, vs. recursively populating a cold cache
 # DRF_INSTANCE_CACHE_POPULATE_COLD=0
-
-# Enable SSL-at-the-proxy
-# SECURE_PROXY_SSL_HEADER="HTTP_X_FORWARDED_PROTOCOL,https"
 
 # Set folder for gathered static files
 # STATIC_ROOT="staticfiles"

--- a/env.dist
+++ b/env.dist
@@ -24,6 +24,9 @@ EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
 # FXA_OAUTH_ENDPOINT="https://oauth-latest.dev.lcip.org/v1"
 # FXA_PROFILE_ENDPOINT="https://latest.dev.lcip.org/profile/v1"
 
+# Set the default page size for pagination, defaults to 10
+# PAGE_SIZE=20
+
 #
 # Other email settings
 #

--- a/env.dist
+++ b/env.dist
@@ -1,114 +1,84 @@
-# Sample Autoenv configuration
-# 1. Install autoenv - https://github.com/kennethreitz/autoenv
-# 2. Copy to .env and customize for your own settings.
-
-#
-# Clear env variables used by project
-#
-unset ALLOWED_HOSTS
-unset DATABASE_URL
-unset DEFAULT_FROM_EMAIL
-unset DJANGO_DEBUG
-unset EMAIL_BACKEND
-unset EMAIL_FILE_PATH
-unset EMAIL_HOST
-unset EMAIL_HOST_PASSWORD
-unset EMAIL_HOST_USER
-unset EMAIL_PORT
-unset EMAIL_SUBJECT_PREFIX
-unset EMAIL_USE_SSL
-unset EMAIL_USE_TLS
-unset EXTRA_INSTALLED_APPS
-unset FXA_OAUTH_ENDPOINT
-unset FXA_PROFILE_ENDPOINT
-unset MDN_ALLOWED_URL_PREFIXES
-unset MEMCACHE_SERVERS
-unset MEMCACHIER_PASSWORD
-unset MEMCACHIER_SERVERS
-unset MEMCACHIER_USERNAME
-unset SECRET_KEY
-unset SECURE_PROXY_SSL_HEADER
-unset SERVER_EMAIL
-unset STATIC_ROOT
+# Sample Environment configuration
+# Copy to .env and customize for your own settings.
 
 #
 # Most common config
 #
 
 # Enable Django's debug mode - database logging, detailed tracebacks, etc.
-export DJANGO_DEBUG=1
+DJANGO_DEBUG=1
 
 # Set the email backend, defaults to SMTP backend
-export EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
+EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
 
 # Database config - See https://github.com/kennethreitz/dj-database-url
-# export DATABASE_URL="postgres://dbuser:dbpassword@localhost:5432/dbname"
+# DATABASE_URL="postgres://dbuser:dbpassword@localhost:5432/dbname"
 
 # Enable memcache
-# export MEMCACHE_SERVERS='localhost:11211'
+# MEMCACHE_SERVERS='localhost:11211'
 
 # Choose Django's SECRET_KEY
-# export SECRET_KEY="I am strangely compelled to change this."
+# SECRET_KEY="I am strangely compelled to change this."
 
 # Set Firefox Account to development settings
-# export FXA_OAUTH_ENDPOINT="https://oauth-latest.dev.lcip.org/v1"
-# export FXA_PROFILE_ENDPOINT="https://latest.dev.lcip.org/profile/v1"
+# FXA_OAUTH_ENDPOINT="https://oauth-latest.dev.lcip.org/v1"
+# FXA_PROFILE_ENDPOINT="https://latest.dev.lcip.org/profile/v1"
 
 #
 # Other email settings
 #
 
 # Comma-separated list of admin names, emails
-# export ADMIN_NAMES="alice,bob"
-# export ADMIN_EMAILS="alice@example.com,bob@example.com"
+# ADMIN_NAMES="alice,bob"
+# ADMIN_EMAILS="alice@example.com,bob@example.com"
 
 # SMTP settings
-# export EMAIL_HOST="smtp.example.com"
-# export EMAIL_PORT=25
-# export EMAIL_HOST_USER=""
-# export EMAIL_HOST_PASSWORD=""
-# export EMAIL_USE_TLS=1
-# export EMAIL_USE_SSL=1
+# EMAIL_HOST="smtp.example.com"
+# EMAIL_PORT=25
+# EMAIL_HOST_USER=""
+# EMAIL_HOST_PASSWORD=""
+# EMAIL_USE_TLS=1
+# EMAIL_USE_SSL=1
 
 # Other mail settings
-# export EMAIL_SUBJECT_PREFIX="[browsercompat] "
-# export EMAIL_FILE_PATH=""
-# export SERVER_EMAIL="root@localhost"
-# export DEFAULT_FROM_EMAIL="webmaster@localhost"
+# EMAIL_SUBJECT_PREFIX="[browsercompat] "
+# EMAIL_FILE_PATH=""
+# SERVER_EMAIL="root@localhost"
+# DEFAULT_FROM_EMAIL="webmaster@localhost"
 
 #
 # Less common config
 #
 
 # Comma-separated list of allowed hosts, used in non-debug mode
-# export ALLOWED_HOSTS="adj-noun.herokoapp.com,adj-noun.co"
+# ALLOWED_HOSTS="adj-noun.herokoapp.com,adj-noun.co"
 
 # Comma-separated list of extra apps to add to INSTALLED_APPS
-# export EXTRA_INSTALLED_APPS="gunicorn"
+# EXTRA_INSTALLED_APPS="gunicorn"
 
 # Memcache w/ username/password security
-# export MEMCACHE_USERNAME='username'
-# export MEMCACHE_PASSWORD='password'
+# MEMCACHE_USERNAME='username'
+# MEMCACHE_PASSWORD='password'
 
 # Memcachier config, heroku-friendly alternate to memcache config
-# export MEMCACHIER_SERVERS="X.dev.ec2.memcachier.com:11211"
-# export MEMCACHIER_USERNAME="username"
-# export MEMCACHIER_PASSWORD="password"
+# MEMCACHIER_SERVERS="X.dev.ec2.memcachier.com:11211"
+# MEMCACHIER_USERNAME="username"
+# MEMCACHIER_PASSWORD="password"
 
 # Comma-separated list of URL prefixes allowed by the importer / scraper
-# export MDN_ALLOWED_URL_PREFIXES="http://localhost:8080"
+# MDN_ALLOWED_URL_PREFIXES="http://localhost:8080"
 
 # Disable DRF Instance Cache, for big imports
-# export USE_DRF_INSTANCE_CACHE=0
+# USE_DRF_INSTANCE_CACHE=0
 
 # Choose eventual consistency, vs. recursively populating a cold cache
-# export DRF_INSTANCE_CACHE_POPULATE_COLD=0
+# DRF_INSTANCE_CACHE_POPULATE_COLD=0
 
 # Enable SSL-at-the-proxy
-# export SECURE_PROXY_SSL_HEADER="HTTP_X_FORWARDED_PROTOCOL,https"
+# SECURE_PROXY_SSL_HEADER="HTTP_X_FORWARDED_PROTOCOL,https"
 
 # Set folder for gathered static files
-# export STATIC_ROOT="staticfiles"
+# STATIC_ROOT="staticfiles"
 
 # Set the site ID
-# export SITE_ID="2"
+# SITE_ID="2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,9 @@ django-extensions==1.6.1
 # History of changes to models
 django-simple-history==1.7.0
 
-# Configure database from env
+# Configure from env
 dj-database-url==0.3.0
+python-decouple==3.0
 
 # Better test runner (included in settings)
 nose==1.3.7

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -60,7 +60,7 @@ SECRET_KEY - Overrides SECRET_KEY
 SECURE_PROXY_SSL_HEADER - 'HTTP_X_FORWARDED_PROTOCOL,https' to enable
 SERVER_EMAIL - Email "From" address for error messages to admins
 STATIC_ROOT - Overrides STATIC_ROOT
-
+PAGE_SIZE - Items per page, default 10
 """
 from os import path
 import sys
@@ -324,7 +324,7 @@ REST_FRAMEWORK = {
     ],
     'VIEW_NAME_FUNCTION': 'webplatformcompat.utils.get_view_name',
     'DEFAULT_PAGINATION_CLASS': 'webplatformcompat.pagination.Pagination',
-    'PAGE_SIZE': 10,
+    'PAGE_SIZE': config('PAGE_SIZE', default=10, cast=int),
     'DEFAULT_VERSIONING_CLASS': (
         'rest_framework.versioning.NamespaceVersioning'),
 }

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -31,9 +31,13 @@ BROKER_URL - Broker URL string for Celery
 CELERY_ALWAYS_EAGER - 1 to run all tasks synchronosly. Defaults to 1 if
     BROKER_URL is undefined, or 0 if defined
 CELERY_RESULT_BACKEND - Backend URL string for Celery
+CSRF_COOKIE_HTTPONLY - Prevent in-page JS from accessing CSRF token
+CSRF_COOKIE_SECURE - Only send CSRF cookies on HTTPS connections
 DATABASE_URL - See https://github.com/kennethreitz/dj-database-url
 DEFAULT_FROM_EMAIL - "From" email for emails to users
 DJANGO_DEBUG - 1 to enable, 0 to disable, default disabled
+DRF_INSTANCE_CACHE_POPULATE_COLD - 1 to recursively populate a cold cache on
+    updates, 0 to be eventually consistent, default enabled
 EMAIL_BACKEND - The backend for email services
 EMAIL_FILE_PATH - File path when FileSystemStorage is used
 EMAIL_HOST - SMTP server, default localhost
@@ -47,20 +51,26 @@ EXTRA_INSTALLED_APPS - comma-separated list of apps to add to INSTALLED_APPS
 FXA_OAUTH_ENDPOINT - Override for Firefox Account OAuth2 endpoint
 FXA_PROFILE_ENDPOINT - Override for Firefox Account profile endpoint
 MDN_ALLOWED_URL_PREFIXES - comma-separated list of URL prefixes allowed by
-  the scraper
+    the scraper
 MDN_SHOW_REPARSE - 1 to show Reparse button, defaults to DEBUG
 MEMCACHE_SERVERS - semicolon-separated list of memcache servers
 MEMCACHE_USERNAME - username for memcache servers
 MEMCACHE_PASSWORD - password for memcache servers
-REDIS_URL - Redis URL string to use Redis for caching
-USE_DRF_INSTANCE_CACHE - 1 to enable, 0 to disable, default enabled
-DRF_INSTANCE_CACHE_POPULATE_COLD - 1 to recursively populate a cold cache on
-  updates, 0 to be eventually consistent, default enabled
-SECRET_KEY - Overrides SECRET_KEY
-SECURE_PROXY_SSL_HEADER - 'HTTP_X_FORWARDED_PROTOCOL,https' to enable
-SERVER_EMAIL - Email "From" address for error messages to admins
-STATIC_ROOT - Overrides STATIC_ROOT
 PAGE_SIZE - Items per page, default 10
+REDIS_URL - Redis URL string to use Redis for caching
+SECRET_KEY - Overrides SECRET_KEY
+SECURE_BROWSER_XSS_FILTER - Enable browser-based XSS protection
+SECURE_CONTENT_TYPE_NOSNIFF - Add nosniff header to disallow browser guessing
+SECURE_HSTS_INCLUDE_SUBDOMAINS - Strict Transport Security for subdomains
+SECURE_HSTS_SECONDS - Number of seconds for Strict Transport Security header,
+    0 to disable (default)
+SECURE_PROXY_SSL_HEADER - 'HTTP_X_FORWARDED_PROTOCOL,https' to enable
+SECURE_SSL_REDIRECT - 301 Redirect http:// to https://
+SERVER_EMAIL - Email "From" address for error messages to admins
+SESSION_COOKIE_SECURE - Only send session cookies on HTTPS connections
+STATIC_ROOT - Overrides STATIC_ROOT
+USE_DRF_INSTANCE_CACHE - 1 to enable, 0 to disable, default enabled
+X_FRAME_OPTIONS - Set X-Frame-Options value
 """
 from os import path
 import sys
@@ -92,9 +102,30 @@ SECRET_KEY = config(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
 
+# Security settings
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='', cast=cast_list)
 SECURE_PROXY_SSL_HEADER = config(
     'SECURE_PROXY_SSL_HEADER', default='', cast=cast_list) or None
+SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default=0, cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = config(
+    'SECURE_HSTS_INCLUDE_SUBDOMAINS', default=False, cast=bool)
+SECURE_CONTENT_TYPE_NOSNIFF = config(
+    'SECURE_CONTENT_TYPE_NOSNIFF', default=False, cast=bool)
+SECURE_BROWSER_XSS_FILTER = config(
+    'SECURE_BROWSER_XSS_FILTER', default=False, cast=bool)
+SECURE_SSL_REDIRECT = config(
+    'SECURE_SSL_REDIRECT', default=False, cast=bool)
+SECURE_SSL_HOST = config(
+    'SECURE_SSL_HOST', default='', cast=cast_list) or None
+SECURE_REDIRECT_EXCEMPT = config(
+    'SECURE_REDIRECT_EXCEMPT', default='', cast=cast_list)
+SESSION_COOKIE_SECURE = config(
+    'SESSION_COOKIE_SECURE', default=False, cast=bool)
+CSRF_COOKIE_HTTPONLY = config(
+    'CSRF_COOKIE_HTTPONLY', default=False, cast=bool)
+CSRF_COOKIE_SECURE = config(
+    'CSRF_COOKIE_SECURE', default=False, cast=bool)
+X_FRAME_OPTIONS = config('X_FRAME_OPTIONS', default='SAMEORIGIN')
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
@@ -131,6 +162,7 @@ INSTALLED_APPS.extend(
     config('EXTRA_INSTALLED_APPS', default='', cast=cast_list))
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Use [python-decouple](https://github.com/henriquebastos/python-decouple/) to standardize loading configuration from the environment, and [unipath](https://github.com/mikeorr/Unipath) to make path lookups nicer. Add a bunch of new configuration settings that can be overridden in the environment.

If you were using a ``.env`` file (not sure if anyone was), this changes the format of that file to the one that python-decouple likes. 