### PR TITLE
Bug fixes from 1218237, 1238587

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ data/
 
 # SQLite databases
 *.sqlite3
+
+# Local environment overrides
+.env
+settings.ini

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -154,12 +154,14 @@ if [ $WITH_CELERY -eq 0 ]; then
     unset CELERY_RESULT_BACKEND
     unset BROKER_URL
     export CELERY_ALWAYS_EAGER=1
+    export USE_CACHE=0
 else
     REDIS_DB=7
     export REDIS_URL="redis://localhost/$REDIS_DB"
     export CELERY_RESULT_BACKEND=$REDIS_URL
     export BROKER_URL=$REDIS_URL
     export CELERY_ALWAYS_EAGER=0
+    export USE_CACHE=1
     echo "Flushing Redis DB $REDIS_DB"
     redis-cli -n $REDIS_DB flushdb
 fi

--- a/webplatformcompat/migrations/0001_initial.py
+++ b/webplatformcompat/migrations/0001_initial.py
@@ -104,7 +104,7 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('tree_id', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('level', models.PositiveIntegerField(editable=False, db_index=True)),
-                ('sections', django_extensions.db.fields.json.JSONField(default=b'[]')),
+                ('sections', django_extensions.db.fields.json.JSONField(default='[]')),
                 ('history_id', models.AutoField(serialize=False, primary_key=True)),
                 ('history_date', models.DateTimeField()),
                 ('history_type', models.CharField(max_length=1, choices=[('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')])),

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -70,6 +70,7 @@ SERVER_EMAIL - Email "From" address for error messages to admins
 SESSION_COOKIE_SECURE - Only send session cookies on HTTPS connections
 STATIC_ROOT - Overrides STATIC_ROOT
 USE_DRF_INSTANCE_CACHE - 1 to enable, 0 to disable, default enabled
+USE_CACHE - 1 to enable, 0 to disable, default enabled
 X_FRAME_OPTIONS - Set X-Frame-Options value
 """
 from os import path
@@ -270,8 +271,9 @@ _memcachier_servers = config(
     'MEMCACHIER_SERVERS', default='').replace(',', ';')
 _memcache_servers = config('MEMCACHE_SERVERS', default=_memcachier_servers)
 _redis_url = config('REDIS_URL', default='')
+_use_cache = config('USE_CACHE', default=True, cast=bool) and not TESTING
 
-if _memcache_servers and not TESTING:
+if _memcache_servers and _use_cache:
     _memcachier_username = config('MEMCACHIER_USERNAME', default='')
     _memcachier_password = config('MEMCACHIER_PASSWORD', default='')
     _memcache_username = config(
@@ -302,7 +304,7 @@ if _memcache_servers and not TESTING:
             },
         },
     }
-elif _redis_url and not TESTING:
+elif _redis_url and _use_cache:
     # Use redis
     CACHES = {
         'default': {


### PR DESCRIPTION
These changes were prompted by switching my development environment to use Python 3.5.1 an a ``.env`` file instead of pure environment variables.

Additional work from PR #94 (Refactor and expand settings):
* Ignore user environment files ``.env`` and ``settings.ini``.
* Add a ``USE_CACHE`` setting, to allow disabling the cache in integration tests, even when user environment files define cache connection variables.

Additional work from PR #95 (Python 3.5):
* Adjust initial migration to pretend we never used a byte sequence for a JSON default, instead of changing to a unicode string in migration 0010, so that tests will run under Python 3.5.1.