### PR TITLE
fix bug 1229783 - require integer IDs 

### DIFF
--- a/webplatformcompat/routers.py
+++ b/webplatformcompat/routers.py
@@ -95,10 +95,11 @@ class GroupedRouter(DefaultRouter):
 
                 # Add endpoints that include the format as an extension
                 fmt_name = name
-                fmt_regex_suffix = r'\.(?P<format>(api|json))/?$'
+                fmt_suffixes = '|'.join(
+                    getattr(viewset, 'format_suffixes', ('api', 'json')))
+                fmt_regex_suffix = (
+                    r'\.(?P<format>({}))/?$'.format(fmt_suffixes))
                 fmt_base_pattern = regex.rstrip('$')
-                if name == 'viewfeatures-detail':
-                    fmt_regex_suffix = r'\.(?P<format>(api|json|html))/?$'
                 fmt_regex = fmt_base_pattern + fmt_regex_suffix
                 fmt_view = viewset.as_view(mapping, **route.initkwargs)
                 urls.append(url(fmt_regex, fmt_view, name=fmt_name))

--- a/webplatformcompat/v1/viewsets.py
+++ b/webplatformcompat/v1/viewsets.py
@@ -125,3 +125,4 @@ class ViewFeaturesViewSet(ViewFeaturesBaseViewSet):
     filter_backends = (UnorderedDjangoFilterBackend,)
     filter_fields = ('slug',)
     template_name = 'webplatformcompat/feature-basic-v1.html'
+    namespace = 'v1'

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -396,3 +396,4 @@ class ViewFeaturesViewSet(ViewFeaturesBaseViewSet):
         JsonApiV10Renderer, BrowsableAPIRenderer,
         JsonApiV10TemplateHTMLRenderer)
     template_name = 'webplatformcompat/feature-basic-v2.html'
+    namespace = 'v2'

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -188,6 +188,7 @@ class HistoricalVersionBaseViewSet(ReadOnlyModelViewSet):
 
 class ViewFeaturesBaseViewSet(ReadUpdateModelViewSet):
     queryset = Feature.objects.order_by('id')
+    format_suffixes = ('api', 'json', 'html')
 
     def get_serializer_class(self):
         """Return the serializer to use based on action and query."""

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -2,6 +2,8 @@
 """API endpoints for CRUD operations."""
 
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.shortcuts import redirect
 from django.utils.functional import cached_property
 from django.http import Http404
 from rest_framework.mixins import UpdateModelMixin
@@ -73,18 +75,28 @@ class FieldsExtraMixin(object):
         return serializer_cls.get_fields_extra()
 
 
+class GroupRouterMixin(object):
+    """Extra parameters used by the GroupedRouter."""
+
+    lookup_value_regex = r'\d+'
+    alt_lookup_field = None
+    alt_lookup_value_regex = None
+
+
 class ModelViewSet(
-        PartialPutMixin, CachedViewMixin, FieldsExtraMixin, BaseModelViewSet):
+        PartialPutMixin, CachedViewMixin, FieldsExtraMixin, GroupRouterMixin,
+        BaseModelViewSet):
     """Base class for ViewSets supporting CRUD operations on models."""
 
 
-class ReadOnlyModelViewSet(FieldsExtraMixin, BaseROModelViewSet):
+class ReadOnlyModelViewSet(
+        FieldsExtraMixin, GroupRouterMixin, BaseROModelViewSet):
     """Base class for ViewSets supporting read operations on models."""
 
 
 class ReadUpdateModelViewSet(
         PartialPutMixin, CachedViewMixin, FieldsExtraMixin, UpdateModelMixin,
-        BaseROModelViewSet):
+        GroupRouterMixin, BaseROModelViewSet):
     """Base class for ViewSets supporting read and update operations."""
 
     pass
@@ -189,6 +201,8 @@ class HistoricalVersionBaseViewSet(ReadOnlyModelViewSet):
 class ViewFeaturesBaseViewSet(ReadUpdateModelViewSet):
     queryset = Feature.objects.order_by('id')
     format_suffixes = ('api', 'json', 'html')
+    alt_lookup_field = 'slug'
+    alt_lookup_value_regex = r'[-a-zA-Z0-9_]+'
 
     def get_serializer_class(self):
         """Return the serializer to use based on action and query."""
@@ -246,19 +260,13 @@ class ViewFeaturesBaseViewSet(ReadUpdateModelViewSet):
         falsy = ('0', 'false', 'no')
         return bool(child_pages.lower() not in falsy)
 
-    def get_object_or_404(self, queryset, *filter_args, **filter_kwargs):
-        """The feature can be accessed by primary key or by feature slug."""
-        pk_or_slug = filter_kwargs['pk']
+    def alternate_lookup(self, request, slug, **extra_kwargs):
+        """Lookup features by slug."""
         try:
-            pk = int(pk_or_slug)
-        except ValueError:
-            try:
-                # parent_id is needed by the MPTT model loader,
-                # including it saves a query later.
-                pk = Feature.objects.only('pk', 'parent_id').get(
-                    slug=pk_or_slug).pk
-            except queryset.model.DoesNotExist:
-                raise Http404(
-                    'No %s matches the given query.' % queryset.model)
-        return super(ViewFeaturesBaseViewSet, self).get_object_or_404(
-            queryset, pk=pk)
+            pk = Feature.objects.only('pk').get(slug=slug).pk
+        except Feature.DoesNotExist:
+            raise Http404('No feature has the requested slug.')
+        kwargs = {'pk': pk}
+        kwargs.update(extra_kwargs)
+        url = reverse('%s:viewfeatures-detail' % self.namespace, kwargs=kwargs)
+        return redirect(url)


### PR DESCRIPTION
[bug 1229783](https://bugzilla.mozilla.org/show_bug.cgi?id=1229783) is about a 500 error when using a string ID instead of a integer ID. This is because the code was trying to accept any ID string, so that an integer ID or a slug could be passed, as part of [bug 1078699](https://bugzilla.mozilla.org/show_bug.cgi?id=1078699).

This code changes this behavior:
* expands ``GroupedRouter.get_urls()``, so the code has more control over the generated paths,
* sets the viewset's PK pattern to accept only integer IDs (``r'\d+'``, so that string IDs will return a 404,
* adds the ability to declare an ``alternate_lookup`` viewset method, which can be used with an alternate ID pattern,
* converts viewfeature's views from using ``get_object_or_404`` to ``alternate_lookup`` for looking up features by slugs,
* changes the return on a matching slug from a 200 to a 302 redirect, for a better fit with JSON API v1.0.
* Uses the ``NamespaceMixin`` pattern, which simplified v2 tests, on v1 tests as well.