### PR TITLE
WIP: 1248141: Create vagrant bootstrapping bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ data/
 # SQLite databases
 *.sqlite3
 
+# Vagrant stuff
+.vagrant/
+
 # Local environment overrides
 .env
 settings.ini

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,79 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest:8000, host:8000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "33.33.33.77"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/home/vagrant/src", :nfs => true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Customize the amount of memory on the VM:
+    vb.customize ['modifyvm', :id, '--ostype', 'Ubuntu_64']
+    vb.customize ['modifyvm', :id, '--ioapic', 'on']
+    vb.customize ['modifyvm', :id, '--memory', 2048]
+
+    # Set the name of the VM
+    vb.name = "bc-dev"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+
+  config.vm.provision "shell", path: "provision.sh"
+end

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd ~vagrant/src
+
+# apt-get update
+
+export LC_ALL="en_US.UTF-8"
+locale-gen en_US.UTF-8
+
+# Install install Apache bits
+apt-get install -y -q libapache2-mod-wsgi
+
+# Install dev things
+apt-get install -y -q python-pip python-virtualenv libpython-dev git
+
+# Install postgres
+apt-get install -y -q postgresql postgresql-contrib postgresql-server-dev-9.3
+
+# Run postgres at start
+update-rc.d postgresql enable
+service postgresql start
+
+# Create "vagrant" user and "bc" and "test_bc" databases
+sudo -u postgres psql -c "CREATE USER vagrant WITH PASSWORD 'vagrant';"
+sudo -u postgres psql -c "ALTER USER vagrant SUPERUSER;"
+sudo -u postgres psql -c "CREATE DATABASE bc;"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE bc TO vagrant;"
+sudo -u postgres psql -c "CREATE DATABASE test_bc;"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE test_bc TO vagrant;"
+
+# Install memcached
+apt-get install -y -q memcached libmemcached-dev
+
+# Install gettext (used to compile locales)
+apt-get install -y -q gettext
+
+
+# Build virtual environment
+VENV=/home/vagrant/env/bc
+sudo -H -u vagrant virtualenv $VENV
+
+# Update pip and install BC requirements
+sudo -H -u vagrant -s -- <<EOF
+source $VENV/bin/activate
+pip install --upgrade requests
+pip install --upgrade "pip>=8"
+cd ~/src
+pip install -r requirements/development.txt
+EOF
+
+# Remove unused packages, most of them are related to X server
+# and we don't use X server at all.
+apt-get autoremove -y -q
+
+# Put the database bits in DATABASE_URL
+echo "export DATABASE_URL=\"postgres://vagrant:vagrant@localhost/bc\"" >> /home/vagrant/.bashrc
+
+# Automatically activate the virtual environment in .bashrc
+echo ". $VENV/bin/activate" >> /home/vagrant/.bashrc

--- a/provision.sh
+++ b/provision.sh
@@ -55,8 +55,16 @@ EOF
 # and we don't use X server at all.
 apt-get autoremove -y -q
 
-# Put the database bits in DATABASE_URL
-echo "export DATABASE_URL=\"postgres://vagrant:vagrant@localhost/bc\"" >> /home/vagrant/.bashrc
+# Create a .env
+cat > /home/vagrant/src/.env <<EOF
+DJANGO_DEBUG=1
+EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
+SECRET_KEY="seatec astronomy"
+DATABASE_URL="postgres://vagrant:vagrant@localhost/bc"
+# MEMCACHE_SERVERS='localhost:11211'
+# MEMCACHE_USERNAME=''
+# MEMCACHE_PASSWORD=''
+EOF
 
 # Automatically activate the virtual environment in .bashrc
 echo ". $VENV/bin/activate" >> /home/vagrant/.bashrc


### PR DESCRIPTION
I used a shell script because browsercompat is pretty small and this made it easier to reason about.This was good enough to get a dev environment working so I can do other things. At some point if it's helpful, someone can convert it to ansible or something else. 

I didn't update the docs. I think if this is good enough for public usage, then we might want to update the docs and make this the "one true way". Someone with opinions on that should decide and probably write up a bug for whatever outstanding work is required.

r?