### PR TITLE
bug 1246192 - Add templatetags to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ recursive-include requirements *.txt
 recursive-include webplatformcompat/migrations *.py
 recursive-include webplatformcompat/static *.css *.map *.eot *.svg *.ttf *.woff *.js .keep
 recursive-include webplatformcompat/jinja2 *.html
+recursive-include webplatformcompat/templatetags *.py
 recursive-include webplatformcompat/tests *.py
 recursive-include webplatformcompat/v1 *.py
 recursive-include webplatformcompat/v2 *.py


### PR DESCRIPTION
``make sdist`` QA checks fail because this folder isn't in MANIFEST.in