### PR TITLE
bug 1159354 - Add /api/v#/users/me endpoint

### DIFF
--- a/docs/v1/change-control.rst
+++ b/docs/v1/change-control.rst
@@ -41,13 +41,24 @@ A sample response is:
     :language: json
 
 
-*Note:* `bug 1159354`_ *proposes this method for retrieving the authenticated user*:
+You can also request the authenticated user's resource:
 
-.. code-block:: http
+.. literalinclude:: /v1/raw/user-me-authenticated-request-headers.txt
+    :language: http
 
-    GET /api/v1/users/me HTTP/1.1
-    Host: browsercompat.org
-    Accept: application/vnd.api+json
+The response is a redirect to the user's resource:
+
+.. literalinclude:: /v1/raw/user-me-authenticated-response-headers.txt
+    :language: http
+
+If the request is made anonymously, then the response is an error:
+
+.. literalinclude:: /v1/raw/user-me-anon-response-headers.txt
+    :language: http
+
+.. literalinclude:: /v1/raw/user-me-anon-response-body.json
+    :language: json
+
 
 Changesets
 ----------
@@ -118,5 +129,4 @@ A sample response is:
 .. _historical_supports: history.html#historical-supports
 .. _historical_versions: history.html#historical-versions
 
-.. _`bug 1159354`: https://bugzilla.mozilla.org/show_bug.cgi?id=1159354
 .. _`ISO 8601`: http://en.wikipedia.org/wiki/ISO_8601

--- a/docs/v1/doc_cases.json
+++ b/docs/v1/doc_cases.json
@@ -14,6 +14,24 @@
             "created": "2015-04-28T18:06:48.567514Z"
         }
     }, {
+        "name": "user-me-anon",
+        "method": "GET",
+        "endpoint": "users/me",
+        "user": false,
+        "status": 401,
+        "standardize": {
+            "created": "2016-02-09T10:08:13.685000Z"
+        }
+    }, {
+        "name": "user-me-authenticated",
+        "method": "GET",
+        "endpoint": "users/me",
+        "user": true,
+        "status": 302,
+        "standardize": {
+            "created": "2016-02-09T10:10:30.633000Z"
+        }
+    }, {
         "name": "browser-list",
         "method": "GET",
         "endpoint": "browsers"

--- a/docs/v1/raw/user-me-anon-request-headers.txt
+++ b/docs/v1/raw/user-me-anon-request-headers.txt
@@ -1,0 +1,3 @@
+GET /api/v1/users/me HTTP/1.1
+Host: browsercompat.org
+Accept: application/vnd.api+json

--- a/docs/v1/raw/user-me-anon-response-body.json
+++ b/docs/v1/raw/user-me-anon-response-body.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+        {
+            "detail": "Authentication credentials were not provided.",
+            "status": "401"
+        }
+    ]
+}

--- a/docs/v1/raw/user-me-anon-response-headers.txt
+++ b/docs/v1/raw/user-me-anon-response-headers.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 401 UNAUTHORIZED
+Content-Type: application/vnd.api+json
+WWW-Authenticate: Bearer realm="api"

--- a/docs/v1/raw/user-me-authenticated-request-headers.txt
+++ b/docs/v1/raw/user-me-authenticated-request-headers.txt
@@ -1,0 +1,4 @@
+GET /api/v1/users/me HTTP/1.1
+Host: browsercompat.org
+Accept: application/vnd.api+json
+Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h

--- a/docs/v1/raw/user-me-authenticated-response-headers.txt
+++ b/docs/v1/raw/user-me-authenticated-response-headers.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 302 FOUND
+Content-Type: text/html; charset=utf-8
+Location: https://browsercompat.org/api/v1/users/1

--- a/docs/v2/doc_cases.json
+++ b/docs/v2/doc_cases.json
@@ -14,6 +14,24 @@
             "created": "2016-01-08T22:22:03.989333Z"
         }
     }, {
+        "name": "user-me-anon",
+        "method": "GET",
+        "endpoint": "users/me",
+        "user": false,
+        "status": 401,
+        "standardize": {
+            "created": "2016-02-09T10:08:13.685000Z"
+        }
+    }, {
+        "name": "user-me-authenticated",
+        "method": "GET",
+        "endpoint": "users/me",
+        "user": true,
+        "status": 302,
+        "standardize": {
+            "created": "2016-02-09T10:10:30.633000Z"
+        }
+    }, {
         "name": "user-related-changesets",
         "method": "GET",
         "endpoint": "users/1/changesets",

--- a/docs/v2/raw/user-me-anon-request-headers.txt
+++ b/docs/v2/raw/user-me-anon-request-headers.txt
@@ -1,0 +1,3 @@
+GET /api/v2/users/me HTTP/1.1
+Host: browsercompat.org
+Accept: application/vnd.api+json

--- a/docs/v2/raw/user-me-anon-response-body.json
+++ b/docs/v2/raw/user-me-anon-response-body.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+        {
+            "detail": "Authentication credentials were not provided.",
+            "status": "401"
+        }
+    ]
+}

--- a/docs/v2/raw/user-me-anon-response-headers.txt
+++ b/docs/v2/raw/user-me-anon-response-headers.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 401 UNAUTHORIZED
+Content-Type: application/vnd.api+json
+WWW-Authenticate: Bearer realm="api"

--- a/docs/v2/raw/user-me-authenticated-request-headers.txt
+++ b/docs/v2/raw/user-me-authenticated-request-headers.txt
@@ -1,0 +1,4 @@
+GET /api/v2/users/me HTTP/1.1
+Host: browsercompat.org
+Accept: application/vnd.api+json
+Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h

--- a/docs/v2/raw/user-me-authenticated-response-headers.txt
+++ b/docs/v2/raw/user-me-authenticated-response-headers.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 302 FOUND
+Content-Type: text/html; charset=utf-8
+Location: https://browsercompat.org/api/v2/users/1

--- a/docs/v2/resources.rst
+++ b/docs/v2/resources.rst
@@ -312,13 +312,23 @@ Here's an example **user**:
 .. literalinclude:: /v2/raw/user-by-id-response-body.json
     :language: json
 
-*Note:* `bug 1159354`_ *proposes this method for retrieving the authenticated user*:
+You can also request the authenticated user's resource:
 
-.. code-block:: http
+.. literalinclude:: /v2/raw/user-me-authenticated-request-headers.txt
+    :language: http
 
-    GET /api/v2/users/me HTTP/1.1
-    Host: browsercompat.org
-    Accept: application/vnd.api+json
+The response is a redirect to the user's resource:
+
+.. literalinclude:: /v2/raw/user-me-authenticated-response-headers.txt
+    :language: http
+
+If the request is made anonymously, then the response is an error:
+
+.. literalinclude:: /v2/raw/user-me-anon-response-headers.txt
+    :language: http
+
+.. literalinclude:: /v2/raw/user-me-anon-response-body.json
+    :language: json
 
 
 Changesets
@@ -543,7 +553,6 @@ Here is a sample **historical_maturity**:
 
 .. _`bug 1078699`: https://bugzilla.mozilla.org/show_bug.cgi?id=1078699
 .. _`bug 1078699`: https://bugzilla.mozilla.org/show_bug.cgi?id=1078699
-.. _`bug 1159354`: https://bugzilla.mozilla.org/show_bug.cgi?id=1159354
 .. _`bug 1216786`: https://bugzilla.mozilla.org/show_bug.cgi?id=1216786
 .. _`bug 1240785`: https://bugzilla.mozilla.org/show_bug.cgi?id=1240785
 .. _non-linguistic: http://www.w3.org/International/questions/qa-no-language#nonlinguistic

--- a/tools/integration_requests.py
+++ b/tools/integration_requests.py
@@ -351,7 +351,8 @@ class CaseRunner(object):
             raw_value = response.headers[header]
             value = self.parse_header(header, raw_value, 'response')
             if value:
-                parsed['response']['headers'][header.title()] = value
+                fixed_header = header.title().replace('Www', 'WWW')
+                parsed['response']['headers'][fixed_header] = value
 
         # Process response body
         body = response.text
@@ -393,15 +394,17 @@ class CaseRunner(object):
                 return value
             elif header.lower() not in (
                     'accept-encoding', 'connection', 'user-agent', 'referer'):
-                print('Unexpected request header %s: %s', header, value)
+                print('Unexpected request header %s: %s' % (header, value))
                 return value
         else:
-            if header.lower() == 'content-type':
+            if header.lower() in ('content-type', 'www-authenticate'):
                 return value
+            elif header.lower() == 'location':
+                return value.replace(api, self.doc_base_url)
             elif header.lower() not in (
                     'allow', 'date', 'server', 'vary', 'x-frame-options',
                     'content-length'):
-                print('Unexpected response header %s: %s', header, value)
+                print('Unexpected response header %s: %s' % (header, value))
                 return value
 
 

--- a/webplatformcompat/tests/test_viewsets.py
+++ b/webplatformcompat/tests/test_viewsets.py
@@ -14,8 +14,27 @@ from webplatformcompat.models import Feature
 from .base import APITestCase
 
 
+class TestUserBaseViewset(APITestCase):
+    """Test users resource viewset."""
+
+    __test__ = False  # Don't test against an unversioned API
+
+    def setUp(self):
+        self.me_url = self.api_reverse('user-me')
+
+    def test_me_anonymous(self):
+        response = self.client.get(self.me_url)
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_me_logged_in(self):
+        self.login_user()
+        response = self.client.get(self.me_url)
+        expected_url = self.api_reverse('user-detail', pk=self.user.pk)
+        self.assertRedirects(response, expected_url)
+
+
 class TestViewFeatureBaseViewset(APITestCase):
-    __test__ = False  # Don't test again an unversioned API
+    __test__ = False  # Don't test against an unversioned API
 
     def setUp(self):
         self.queryset = Feature.objects.all()

--- a/webplatformcompat/tests/v1/base.py
+++ b/webplatformcompat/tests/v1/base.py
@@ -4,13 +4,16 @@ from ..base import TestCase as BaseTestCase
 from ..base import APITestCase as BaseAPITestCase
 
 
-class TestCase(BaseTestCase):
+class NamespaceMixin(object):
+    """Designate the namespace for tests."""
+
+    namespace = 'v1'
+    __test__ = True  # Run these tests if disabled in base class
+
+
+class TestCase(BaseTestCase, NamespaceMixin):
     """Useful methods for testing."""
 
-    namespace = 'v1'
 
-
-class APITestCase(BaseAPITestCase):
+class APITestCase(BaseAPITestCase, NamespaceMixin):
     """Useful methods for testing API endpoints."""
-
-    namespace = 'v1'

--- a/webplatformcompat/tests/v1/test_viewsets.py
+++ b/webplatformcompat/tests/v1/test_viewsets.py
@@ -12,8 +12,8 @@ from webplatformcompat.models import (
     Browser, Feature, Maturity, Section, Specification, Support, Version)
 
 from webplatformcompat.v1.viewsets import ViewFeaturesViewSet
-from .base import APITestCase
-from ..test_viewsets import TestViewFeatureBaseViewset
+from .base import APITestCase, NamespaceMixin
+from ..test_viewsets import TestUserBaseViewset, TestViewFeatureBaseViewset
 
 
 class TestBrowserViewset(APITestCase):
@@ -441,9 +441,12 @@ class TestHistoricaBrowserViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
 
-class TestViewFeatureViewset(TestViewFeatureBaseViewset):
-    namespace = 'v1'
-    __test__ = True
+class TestUserViewset(NamespaceMixin, TestUserBaseViewset):
+    """Test users/me UserViewSet."""
+
+
+class TestViewFeatureViewset(NamespaceMixin, TestViewFeatureBaseViewset):
+    """Test helper functions on ViewFeaturesViewSet."""
 
     def setUp(self):
         super(TestViewFeatureViewset, self).setUp()

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -13,7 +13,7 @@ from webplatformcompat.models import (
 
 from webplatformcompat.v2.viewsets import ViewFeaturesViewSet
 from .base import APITestCase, NamespaceMixin
-from ..test_viewsets import TestViewFeatureBaseViewset
+from ..test_viewsets import TestUserBaseViewset, TestViewFeatureBaseViewset
 
 
 class TestBrowserViewset(APITestCase):
@@ -972,6 +972,10 @@ class TestHistoricaBrowserViewset(APITestCase):
             'historicalbrowser-relationships-browser', pk=self.history.pk)
         response = self.client.get(url, HTTP_ACCEPT='application/vnd.api+json')
         self.assertEqual(200, response.status_code, response.data)
+
+
+class TestUserViewset(NamespaceMixin, TestUserBaseViewset):
+    """Test users/me UserViewSet."""
 
 
 class TestViewFeatureViewset(NamespaceMixin, TestViewFeatureBaseViewset):

--- a/webplatformcompat/v1/viewsets.py
+++ b/webplatformcompat/v1/viewsets.py
@@ -78,6 +78,7 @@ class ChangesetViewSet(WritableMixin, ChangesetBaseViewSet):
 
 class UserViewSet(ReadOnlyMixin, UserBaseViewSet):
     filter_fields = ('username',)
+    namespace = 'v1'
 
 
 #

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -313,6 +313,7 @@ class UserViewSet(ReadOnlyMixin, UserBaseViewSet):
     related_routes = (
         RelatedListRoute('changesets', 'ChangesetViewSet', 'user_id'),
     )
+    namespace = 'v2'
 
 
 #

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -6,6 +6,8 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.utils.functional import cached_property
 from django.http import Http404
+from rest_framework.decorators import list_route
+from rest_framework.exceptions import NotAuthenticated
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.viewsets import ModelViewSet as BaseModelViewSet
 from rest_framework.viewsets import ReadOnlyModelViewSet as BaseROModelViewSet
@@ -153,6 +155,17 @@ class ChangesetBaseViewSet(ModelViewSet):
 class UserBaseViewSet(CachedViewMixin, ReadOnlyModelViewSet):
     queryset = User.objects.order_by('id')
     serializer_class = UserSerializer
+
+    @list_route()
+    def me(self, request, **extra_kwargs):
+        """Redirect to the authenticated user's resource."""
+        if request.user.is_anonymous():
+            raise NotAuthenticated()
+        else:
+            kwargs = {'pk': request.user.pk}
+            kwargs.update(extra_kwargs)
+            url = reverse('%s:user-detail' % self.namespace, kwargs=kwargs)
+            return redirect(url)
 
 
 #


### PR DESCRIPTION
Add "reflection" endpoints of ``/api/v1/users/me`` and ``/api/v2/users/me``, that clients (such as the [C&M](https://github.com/mdn/browsercompat-cm) interface) can use to check the validity of credentials and get the details of the authenticated user. Updates unit and integration tests, documentation.