### PR TITLE
fix bug 1230604 - Use OAuth2 tokens in integration tests and documentation.

### DIFF
--- a/docs/v1/raw/browser-create-in-changeset-1-request-headers.txt
+++ b/docs/v1/raw/browser-create-in-changeset-1-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/changesets HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 53
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-create-in-changeset-2-request-headers.txt
+++ b/docs/v1/raw/browser-create-in-changeset-2-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/browsers?changeset=4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 220
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-create-in-changeset-3-request-headers.txt
+++ b/docs/v1/raw/browser-create-in-changeset-3-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/changesets/4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 52
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-create-maximized-request-headers.txt
+++ b/docs/v1/raw/browser-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/browsers HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 229
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-create-minimal-request-headers.txt
+++ b/docs/v1/raw/browser-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/browsers HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 132
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-delete-request-headers.txt
+++ b/docs/v1/raw/browser-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/browsers/16 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-revert-request-headers.txt
+++ b/docs/v1/raw/browser-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 91
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-update-full-request-headers.txt
+++ b/docs/v1/raw/browser-update-full-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1000
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-update-partial-request-headers.txt
+++ b/docs/v1/raw/browser-update-partial-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 78
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/browser-update-versions-order-request-headers.txt
+++ b/docs/v1/raw/browser-update-versions-order-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 205
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-01-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-01-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/specifications HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 320
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-02-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-02-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/specifications HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 282
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-03-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-03-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 306
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-04-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-04-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 307
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-05-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-05-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 164
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-06-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-06-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 176
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-07-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-07-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 266
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-08-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-08-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/18 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 116
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-09-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-09-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/18 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 137
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-add-sections-10-request-headers.txt
+++ b/docs/v1/raw/feature-add-sections-10-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/18 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 137
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-create-maximized-request-headers.txt
+++ b/docs/v1/raw/feature-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 472
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-create-minimal-request-headers.txt
+++ b/docs/v1/raw/feature-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 88
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-delete-request-headers.txt
+++ b/docs/v1/raw/feature-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/features/15 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-revert-request-headers.txt
+++ b/docs/v1/raw/feature-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/12 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 92
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-set-children-order-add-fails-request-headers.txt
+++ b/docs/v1/raw/feature-set-children-order-add-fails-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/2 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 287
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-set-children-order-omit-fails-request-headers.txt
+++ b/docs/v1/raw/feature-set-children-order-omit-fails-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/2 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 243
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-set-children-order-request-headers.txt
+++ b/docs/v1/raw/feature-set-children-order-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/2 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 265
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/feature-update-request-headers.txt
+++ b/docs/v1/raw/feature-update-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/features/12 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 51
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/maturity-create-request-headers.txt
+++ b/docs/v1/raw/maturity-create-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/maturities HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 106
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/maturity-delete-request-headers.txt
+++ b/docs/v1/raw/maturity-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/maturities/10 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/maturity-revert-request-headers.txt
+++ b/docs/v1/raw/maturity-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/maturities/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 93
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/maturity-update-request-headers.txt
+++ b/docs/v1/raw/maturity-update-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/maturities/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 220
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/section-create-maximized-request-headers.txt
+++ b/docs/v1/raw/section-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 374
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/section-create-minimal-request-headers.txt
+++ b/docs/v1/raw/section-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 152
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/section-delete-request-headers.txt
+++ b/docs/v1/raw/section-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/sections/5 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/section-revert-request-headers.txt
+++ b/docs/v1/raw/section-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/sections/6 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 91
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/section-update-request-headers.txt
+++ b/docs/v1/raw/section-update-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/sections/6 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 56
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/specification-create-request-headers.txt
+++ b/docs/v1/raw/specification-create-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/specifications HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 313
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/specification-delete-request-headers.txt
+++ b/docs/v1/raw/specification-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/specifications/4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/specification-revert-request-headers.txt
+++ b/docs/v1/raw/specification-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/specifications/5 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 97
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/specification-update-request-headers.txt
+++ b/docs/v1/raw/specification-update-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/specifications/5 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 57
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/support-create-maximized-request-headers.txt
+++ b/docs/v1/raw/support-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/supports HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 446
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/support-create-minimal-request-headers.txt
+++ b/docs/v1/raw/support-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/supports HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 111
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/support-delete-request-headers.txt
+++ b/docs/v1/raw/support-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/supports/28 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/support-revert-request-headers.txt
+++ b/docs/v1/raw/support-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/supports/26 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 92
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/support-update-request-headers.txt
+++ b/docs/v1/raw/support-update-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/supports/26 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 56
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/user-me-authenticated-request-headers.txt
+++ b/docs/v1/raw/user-me-authenticated-request-headers.txt
@@ -1,4 +1,4 @@
 GET /api/v1/users/me HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v1/raw/version-create-error-blank-version-request-headers.txt
+++ b/docs/v1/raw/version-create-error-blank-version-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 135
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-create-error-status-beta-text-version-request-headers.txt
+++ b/docs/v1/raw/version-create-error-status-beta-text-version-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 139
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-create-error-status-current-version-text-request-headers.txt
+++ b/docs/v1/raw/version-create-error-status-current-version-text-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 152
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-create-error-status-future-version-numeric-request-headers.txt
+++ b/docs/v1/raw/version-create-error-status-future-version-numeric-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 138
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-create-error-status-unknown-version-current-request-headers.txt
+++ b/docs/v1/raw/version-create-error-status-unknown-version-current-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 142
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-create-maximized-request-headers.txt
+++ b/docs/v1/raw/version-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1200
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-create-minimal-request-headers.txt
+++ b/docs/v1/raw/version-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 110
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-delete-request-headers.txt
+++ b/docs/v1/raw/version-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v1/versions/49 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-revert-request-headers.txt
+++ b/docs/v1/raw/version-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 92
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-update-error-status-future-version-numeric-request-headers.txt
+++ b/docs/v1/raw/version-update-error-status-future-version-numeric-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 54
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-update-request-headers.txt
+++ b/docs/v1/raw/version-update-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 55
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/version-update-version-change-ignored-request-headers.txt
+++ b/docs/v1/raw/version-update-version-change-ignored-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 82
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-1-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-1-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/changesets HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 107
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/versions?changeset=36 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 138
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v1/supports?changeset=36 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 112
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-4-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-4-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/changesets/36 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 52
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v1/raw/view-feature-update-put-subfeature-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-put-subfeature-request-headers.txt
@@ -1,7 +1,6 @@
 PUT /api/v1/view_features/5 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 349
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-create-in-changeset-1-request-headers.txt
+++ b/docs/v2/raw/browser-create-in-changeset-1-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/changesets HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 115
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-create-in-changeset-2-request-headers.txt
+++ b/docs/v2/raw/browser-create-in-changeset-2-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/browsers?changeset=4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 298
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-create-in-changeset-3-request-headers.txt
+++ b/docs/v2/raw/browser-create-in-changeset-3-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/changesets/4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 114
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-create-maximized-request-headers.txt
+++ b/docs/v2/raw/browser-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/browsers HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 315
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-create-minimal-request-headers.txt
+++ b/docs/v2/raw/browser-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/browsers HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 206
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-delete-request-headers.txt
+++ b/docs/v2/raw/browser-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/browsers/16 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-revert-relationships-history-current-request-headers.txt
+++ b/docs/v2/raw/browser-revert-relationships-history-current-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/browsers/9/relationships/history_current HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 81
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-revert-request-headers.txt
+++ b/docs/v2/raw/browser-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 279
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-update-full-request-headers.txt
+++ b/docs/v2/raw/browser-update-full-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1470
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-update-partial-request-headers.txt
+++ b/docs/v2/raw/browser-update-partial-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 167
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-update-relationships-versions-order-request-headers.txt
+++ b/docs/v2/raw/browser-update-relationships-versions-order-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/browsers/9/relationships/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 402
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/browser-update-versions-order-request-headers.txt
+++ b/docs/v2/raw/browser-update-versions-order-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/browsers/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 810
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/changeset-related-user-response-body.json
+++ b/docs/v2/raw/changeset-related-user-response-body.json
@@ -20,12 +20,7 @@
                     "self": "https://browsercompat.org/api/v2/users/1/relationships/changesets",
                     "related": "https://browsercompat.org/api/v2/users/1/changesets"
                 },
-                "data": [
-                    {
-                        "type": "changesets",
-                        "id": "1"
-                    }
-                ]
+                "data": []
             }
         }
     }

--- a/docs/v2/raw/feature-add-sections-01-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-01-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/specifications HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 546
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-02-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-02-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/specifications HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 508
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-03-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-03-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 540
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-04-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-04-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 541
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-05-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-05-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 372
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-06-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-06-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 384
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-07-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-07-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 478
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-08-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-08-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/18 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 314
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-09-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-09-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/18/relationships/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 172
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-add-sections-10-request-headers.txt
+++ b/docs/v2/raw/feature-add-sections-10-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/18 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 437
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-create-maximized-request-headers.txt
+++ b/docs/v2/raw/feature-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 700
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-create-minimal-request-headers.txt
+++ b/docs/v2/raw/feature-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 154
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-delete-request-headers.txt
+++ b/docs/v2/raw/feature-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/features/15 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-revert-request-headers.txt
+++ b/docs/v2/raw/feature-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/12 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 281
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-set-children-order-add-fails-request-headers.txt
+++ b/docs/v2/raw/feature-set-children-order-add-fails-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/2 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1300
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-set-children-order-omit-fails-request-headers.txt
+++ b/docs/v2/raw/feature-set-children-order-omit-fails-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/2 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1052
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-set-children-order-request-headers.txt
+++ b/docs/v2/raw/feature-set-children-order-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/2 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1176
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-set-relationship-children-order-request-headers.txt
+++ b/docs/v2/raw/feature-set-relationship-children-order-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/2/relationships/children HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 624
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/feature-update-request-headers.txt
+++ b/docs/v2/raw/feature-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/features/12 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 133
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/maturity-create-request-headers.txt
+++ b/docs/v2/raw/maturity-create-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/maturities HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 180
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/maturity-delete-request-headers.txt
+++ b/docs/v2/raw/maturity-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/maturities/10 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/maturity-revert-request-headers.txt
+++ b/docs/v2/raw/maturity-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/maturities/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 283
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/maturity-update-request-headers.txt
+++ b/docs/v2/raw/maturity-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/maturities/9 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 321
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-create-maximized-request-headers.txt
+++ b/docs/v2/raw/section-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 758
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-create-minimal-request-headers.txt
+++ b/docs/v2/raw/section-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/sections HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 362
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-delete-request-headers.txt
+++ b/docs/v2/raw/section-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/sections/7 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-relationships-features-update-request-headers.txt
+++ b/docs/v2/raw/section-relationships-features-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/sections/8/relationships/features HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 174
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-relationships-specification-update-request-headers.txt
+++ b/docs/v2/raw/section-relationships-specification-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/sections/8/relationships/specification HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 75
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-revert-request-headers.txt
+++ b/docs/v2/raw/section-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/sections/8 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 218
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/section-update-request-headers.txt
+++ b/docs/v2/raw/section-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/sections/8 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 272
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/specification-create-request-headers.txt
+++ b/docs/v2/raw/specification-create-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/specifications HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 539
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/specification-delete-request-headers.txt
+++ b/docs/v2/raw/specification-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/specifications/7 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/specification-relationships-maturity-update-request-headers.txt
+++ b/docs/v2/raw/specification-relationships-maturity-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/specifications/7/relationships/maturity HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 71
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/specification-revert-request-headers.txt
+++ b/docs/v2/raw/specification-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/specifications/7 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 97
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/specification-update-request-headers.txt
+++ b/docs/v2/raw/specification-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/specifications/7 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 250
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/support-create-maximized-request-headers.txt
+++ b/docs/v2/raw/support-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/supports HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 808
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/support-create-minimal-request-headers.txt
+++ b/docs/v2/raw/support-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/supports HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 395
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/support-delete-request-headers.txt
+++ b/docs/v2/raw/support-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/supports/28 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/support-revert-request-headers.txt
+++ b/docs/v2/raw/support-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/supports/26 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 281
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/support-update-request-headers.txt
+++ b/docs/v2/raw/support-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/supports/26 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 138
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/user-me-authenticated-request-headers.txt
+++ b/docs/v2/raw/user-me-authenticated-request-headers.txt
@@ -1,4 +1,4 @@
 GET /api/v2/users/me HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v2/raw/version-create-error-blank-version-request-headers.txt
+++ b/docs/v2/raw/version-create-error-blank-version-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 335
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-create-error-status-beta-text-version-request-headers.txt
+++ b/docs/v2/raw/version-create-error-status-beta-text-version-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 339
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-create-error-status-current-version-text-request-headers.txt
+++ b/docs/v2/raw/version-create-error-status-current-version-text-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 352
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-create-error-status-future-version-numeric-request-headers.txt
+++ b/docs/v2/raw/version-create-error-status-future-version-numeric-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 338
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-create-error-status-unknown-version-current-request-headers.txt
+++ b/docs/v2/raw/version-create-error-status-unknown-version-current-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 342
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-create-maximized-request-headers.txt
+++ b/docs/v2/raw/version-create-maximized-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 1472
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-create-minimal-request-headers.txt
+++ b/docs/v2/raw/version-create-minimal-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 306
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-delete-request-headers.txt
+++ b/docs/v2/raw/version-delete-request-headers.txt
@@ -1,6 +1,5 @@
 DELETE /api/v2/versions/49 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 0
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-revert-request-headers.txt
+++ b/docs/v2/raw/version-revert-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 281
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-update-error-status-future-version-numeric-request-headers.txt
+++ b/docs/v2/raw/version-update-error-status-future-version-numeric-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 136
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-update-request-headers.txt
+++ b/docs/v2/raw/version-update-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 137
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/version-update-version-change-ignored-request-headers.txt
+++ b/docs/v2/raw/version-update-version-change-ignored-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/versions/21 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 168
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-1-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-1-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/changesets HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 173
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/versions?changeset=56 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 338
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
@@ -1,7 +1,6 @@
 POST /api/v2/supports?changeset=56 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 396
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-4-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-4-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/changesets/56 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 134
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/docs/v2/raw/view-feature-update-put-subfeature-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-put-subfeature-request-headers.txt
@@ -1,7 +1,6 @@
 PATCH /api/v2/view_features/5 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
+Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2
 Content-Length: 590
 Content-Type: application/vnd.api+json
-Cookie: csrftoken=p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn; sessionid=wurexa2wq416ftlvd5plesngwa28183h
-X-Csrftoken: p7FqFyNp6hZS0FJYKyQxVmLrZILldjqn

--- a/tools/common.py
+++ b/tools/common.py
@@ -47,11 +47,12 @@ class ToolParser(argparse.ArgumentParser):
             password - Add --password option
             data - Add --data option
             nocache - Add --no-cache option (default with cache)
+            token - Add --token option
         """
         super(ToolParser, self).__init__(*args, **kwargs)
 
         self.include_set = set(include or [])
-        valid = set(['api', 'user', 'password', 'data', 'nocache'])
+        valid = set(['api', 'user', 'password', 'data', 'nocache', 'token'])
         if self.include_set - valid:
             raise ValueError(
                 'Unknown include items: {}'.format(self.include_set - valid))
@@ -93,6 +94,11 @@ class ToolParser(argparse.ArgumentParser):
                 '--no-cache', action='store_false', default=True,
                 dest='use_cache',
                 help='Ignore cache and redownload files')
+
+        if 'token' in self.include_set:
+            self.add_argument(
+                '--token',
+                help='Use this OAuth2 token for API access.')
 
     def parse_args(self, *args, **kwargs):
         args = super(ToolParser, self).parse_args(*args, **kwargs)

--- a/tools/integration_requests.py
+++ b/tools/integration_requests.py
@@ -175,9 +175,9 @@ class CaseRunner(object):
         out = self.format_response_for_display(response, case)
         header = 'Test Case %d: %s' % (casenum, case['name'])
         print()
-        print(header.encode('utf8'))
+        self.uprint(header)
         print('*' * len(header))
-        print(out.encode('utf8'))
+        self.uprint(out)
         return []
 
     def generate(self, casenum, case, response):
@@ -406,6 +406,19 @@ class CaseRunner(object):
                     'content-length'):
                 print('Unexpected response header %s: %s' % (header, value))
                 return value
+
+    _utf8_safe = None
+
+    def uprint(self, *objects, sep=' ', end='\n'):
+        """Print in unicode or UTF-8 encoded, based on stdout encoding."""
+        if self._utf8_safe is None:
+            from sys import stdout
+            self._utf8_safe = (stdout.encoding.lower() == 'utf-8')
+        if self._utf8_safe:
+            encoded = objects
+        else:
+            encoded = [str(obj).encode('utf8') for obj in objects]
+        print(*encoded, sep=sep, end=end)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update integration tests to generate and use an OAuth2 bearer token instead of a session based on username and password. This also updates the documentation examples to use the token.