### PR TITLE
fix bug 1247690 - Changeset invalidates user instance cache

### DIFF
--- a/docs/v1/raw/user-by-id-response-body.json
+++ b/docs/v1/raw/user-by-id-response-body.json
@@ -9,7 +9,9 @@
             "delete-resource"
         ],
         "links": {
-            "changesets": []
+            "changesets": [
+                "1"
+            ]
         }
     },
     "links": {

--- a/docs/v1/raw/user-by-username-response-body.json
+++ b/docs/v1/raw/user-by-username-response-body.json
@@ -10,7 +10,9 @@
                 "delete-resource"
             ],
             "links": {
-                "changesets": []
+                "changesets": [
+                    "1"
+                ]
             }
         }
     ],

--- a/docs/v2/raw/changeset-related-user-response-body.json
+++ b/docs/v2/raw/changeset-related-user-response-body.json
@@ -20,7 +20,228 @@
                     "self": "https://browsercompat.org/api/v2/users/1/relationships/changesets",
                     "related": "https://browsercompat.org/api/v2/users/1/changesets"
                 },
-                "data": []
+                "data": [
+                    {
+                        "type": "changesets",
+                        "id": "1"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "2"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "3"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "4"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "5"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "6"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "7"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "8"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "9"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "10"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "11"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "12"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "13"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "14"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "15"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "16"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "17"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "18"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "19"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "20"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "21"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "22"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "23"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "24"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "25"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "26"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "27"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "28"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "29"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "30"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "31"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "32"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "33"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "34"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "35"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "36"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "37"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "38"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "39"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "40"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "41"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "42"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "43"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "44"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "45"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "46"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "47"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "48"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "49"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "50"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "51"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "52"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "53"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "54"
+                    },
+                    {
+                        "type": "changesets",
+                        "id": "55"
+                    }
+                ]
             }
         }
     }

--- a/docs/v2/raw/user-by-id-response-body.json
+++ b/docs/v2/raw/user-by-id-response-body.json
@@ -20,7 +20,12 @@
                     "self": "https://browsercompat.org/api/v2/users/1/relationships/changesets",
                     "related": "https://browsercompat.org/api/v2/users/1/changesets"
                 },
-                "data": []
+                "data": [
+                    {
+                        "type": "changesets",
+                        "id": "1"
+                    }
+                ]
             }
         }
     }

--- a/docs/v2/raw/user-by-username-response-body.json
+++ b/docs/v2/raw/user-by-username-response-body.json
@@ -19,7 +19,12 @@
             },
             "relationships": {
                 "changesets": {
-                    "data": []
+                    "data": [
+                        {
+                            "type": "changesets",
+                            "id": "1"
+                        }
+                    ]
                 }
             },
             "links": {

--- a/webplatformcompat/__init__.py
+++ b/webplatformcompat/__init__.py
@@ -1,2 +1,3 @@
 """The BrowserCompat API app."""
 __version__ = '0.1.0'
+default_app_config = 'webplatformcompat.apps.WebPlatformCompatConfig'

--- a/webplatformcompat/apps.py
+++ b/webplatformcompat/apps.py
@@ -14,6 +14,7 @@ class WebPlatformCompatConfig(AppConfig):
         """Register signal handlers when models are loaded."""
         super(WebPlatformCompatConfig, self).ready()
         from django.contrib.auth.models import User
+        from webplatformcompat.history import Changeset
         from webplatformcompat.models import (
             Browser, Feature, Maturity, Section, Specification,
             Support, Version)
@@ -21,6 +22,7 @@ class WebPlatformCompatConfig(AppConfig):
             add_user_to_change_resource_group,
             feature_sections_changed_update_order,
             post_delete_update_cache,
+            post_save_changeset,
             post_save_update_cache)
 
         # Add default API permissions to new users
@@ -48,3 +50,9 @@ class WebPlatformCompatConfig(AppConfig):
                 post_save_update_cache,
                 sender=model,
                 dispatch_uid='post_save_update_cache_%s' % name)
+
+        # Invalidate user instance cache on changeset creation
+        post_save.connect(
+            post_save_changeset,
+            sender=Changeset,
+            dispatch_uid='post_save_changeset')

--- a/webplatformcompat/apps.py
+++ b/webplatformcompat/apps.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Application configuration."""
+from django.apps import AppConfig
+
+
+class WebPlatformCompatConfig(AppConfig):
+    name = 'webplatformcompat'
+    verbose_name = 'WebPlatformCompat'
+
+    def ready(self):
+        super(WebPlatformCompatConfig, self).ready()
+        import webplatformcompat.signals
+        assert webplatformcompat.signals, 'Failed to make flake8 happy'

--- a/webplatformcompat/apps.py
+++ b/webplatformcompat/apps.py
@@ -1,13 +1,50 @@
 # -*- coding: utf-8 -*-
 """Application configuration."""
 from django.apps import AppConfig
+from django.db.models.signals import post_delete, post_save, m2m_changed
 
 
 class WebPlatformCompatConfig(AppConfig):
+    """Configuration for the webplatformcompat app."""
+
     name = 'webplatformcompat'
     verbose_name = 'WebPlatformCompat'
 
     def ready(self):
+        """Register signal handlers when models are loaded."""
         super(WebPlatformCompatConfig, self).ready()
-        import webplatformcompat.signals
-        assert webplatformcompat.signals, 'Failed to make flake8 happy'
+        from django.contrib.auth.models import User
+        from webplatformcompat.models import (
+            Browser, Feature, Maturity, Section, Specification,
+            Support, Version)
+        from webplatformcompat.signals import (
+            add_user_to_change_resource_group,
+            feature_sections_changed_update_order,
+            post_delete_update_cache,
+            post_save_update_cache)
+
+        # Add default API permissions to new users
+        post_save.connect(
+            add_user_to_change_resource_group,
+            sender=User,
+            dispatch_uid='add_user_to_change_resource_group')
+
+        # Invalidate instance cache when features-to-sections changes
+        m2m_changed.connect(
+            feature_sections_changed_update_order,
+            sender=Feature.sections.through,
+            dispatch_uid='m2m_changed_feature_section')
+
+        # Invalidate instance cache on model changes
+        for model in (
+                Browser, Feature, Maturity, Section, Specification,
+                Support, Version, User):
+            name = model.__name__
+            post_delete.connect(
+                post_delete_update_cache,
+                sender=model,
+                dispatch_uid='post_delete_update_cache_%s' % name)
+            post_save.connect(
+                post_save_update_cache,
+                sender=model,
+                dispatch_uid='post_save_update_cache_%s' % name)

--- a/webplatformcompat/models.py
+++ b/webplatformcompat/models.py
@@ -6,10 +6,7 @@ Additional models (Changeset, historical models) are defined in history.py.
 
 from __future__ import unicode_literals
 
-from django.conf import settings
 from django.db import models
-from django.db.models.signals import post_delete, post_save, m2m_changed
-from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django_extensions.db.fields.json import JSONField
@@ -414,85 +411,3 @@ register(Browser, records_class=HistoricalBrowserRecords)
 register(Feature, records_class=HistoricalFeatureRecords)
 register(Maturity, records_class=HistoricalMaturityRecords)
 register(Specification, records_class=HistoricalSpecificationRecords)
-
-
-#
-# Cache invalidation signals
-#
-
-cached_model_names = (
-    'Browser', 'Feature', 'Maturity', 'Section', 'Specification',
-    'Support', 'Version', 'User')
-
-
-@receiver(
-    m2m_changed, sender=Feature.sections.through,
-    dispatch_uid='m2m_changed_feature_section')
-def feature_sections_changed_update_order(
-        sender, instance, action, reverse, model, pk_set, **kwargs):
-    """Maintain feature.section_order."""
-    if action not in ('post_add', 'post_remove', 'post_clear'):
-        # post_clear is not handled, because clear is called in
-        # django.db.models.fields.related.ReverseManyRelatedObjects.__set__
-        # before setting the new order
-        return
-    if getattr(instance, '_delay_cache', False):
-        return
-
-    if model == Section:
-        assert type(instance) == Feature
-        features = [instance]
-        if pk_set:
-            sections = list(Section.objects.filter(pk__in=pk_set))
-        else:
-            sections = []
-    else:
-        if pk_set:
-            features = list(Feature.objects.filter(pk__in=pk_set))
-        else:
-            features = []
-        sections = [instance]
-
-    from .tasks import update_cache_for_instance
-    for feature in features:
-        update_cache_for_instance('Feature', feature.pk, feature)
-    for section in sections:
-        update_cache_for_instance('Section', section.pk, section)
-
-
-@receiver(post_delete, dispatch_uid='post_delete_update_cache')
-def post_delete_update_cache(sender, instance, **kwargs):
-    name = sender.__name__
-    if name in cached_model_names:
-        delay_cache = getattr(instance, '_delay_cache', False)
-        if not delay_cache:
-            from .tasks import update_cache_for_instance
-            update_cache_for_instance(name, instance.pk, instance)
-
-
-@receiver(post_save, dispatch_uid='post_save_update_cache')
-def post_save_update_cache(sender, instance, created, raw, **kwargs):
-    if raw:
-        return
-    name = sender.__name__
-    if name in cached_model_names:
-        delay_cache = getattr(instance, '_delay_cache', False)
-        if not delay_cache:
-            from .tasks import update_cache_for_instance
-            update_cache_for_instance(name, instance.pk, instance)
-
-
-#
-# New user signals
-#
-@receiver(
-    post_save, sender=settings.AUTH_USER_MODEL,
-    dispatch_uid='add_user_to_change_resource_group')
-def add_user_to_change_resource_group(
-        signal, sender, instance, created, raw, **kwargs):
-    if created and not raw:
-        from django.contrib.auth.models import Group
-        instance.groups.add(Group.objects.get(name='change-resource'))
-        if hasattr(instance, 'group_names'):
-            del instance.group_names
-        post_save_update_cache(sender, instance, created, raw, **kwargs)

--- a/webplatformcompat/signals.py
+++ b/webplatformcompat/signals.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Signal handlers for API models."""
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db.models.signals import post_delete, post_save, m2m_changed
+from django.dispatch import receiver
+
+from .models import Feature, Section
+
+cached_model_names = (
+    'Browser', 'Feature', 'Maturity', 'Section', 'Specification',
+    'Support', 'Version', 'User')
+
+
+@receiver(
+    m2m_changed, sender=Feature.sections.through,
+    dispatch_uid='m2m_changed_feature_section')
+def feature_sections_changed_update_order(
+        sender, instance, action, reverse, model, pk_set, **kwargs):
+    """Maintain feature.section_order."""
+    if action not in ('post_add', 'post_remove', 'post_clear'):
+        # post_clear is not handled, because clear is called in
+        # django.db.models.fields.related.ReverseManyRelatedObjects.__set__
+        # before setting the new order
+        return
+    if getattr(instance, '_delay_cache', False):
+        return
+
+    if model == Section:
+        assert type(instance) == Feature
+        features = [instance]
+        if pk_set:
+            sections = list(Section.objects.filter(pk__in=pk_set))
+        else:
+            sections = []
+    else:
+        if pk_set:
+            features = list(Feature.objects.filter(pk__in=pk_set))
+        else:
+            features = []
+        sections = [instance]
+
+    from .tasks import update_cache_for_instance
+    for feature in features:
+        update_cache_for_instance('Feature', feature.pk, feature)
+    for section in sections:
+        update_cache_for_instance('Section', section.pk, section)
+
+
+@receiver(post_delete, dispatch_uid='post_delete_update_cache')
+def post_delete_update_cache(sender, instance, **kwargs):
+    name = sender.__name__
+    if name in cached_model_names:
+        delay_cache = getattr(instance, '_delay_cache', False)
+        if not delay_cache:
+            from .tasks import update_cache_for_instance
+            update_cache_for_instance(name, instance.pk, instance)
+
+
+@receiver(post_save, dispatch_uid='post_save_update_cache')
+def post_save_update_cache(sender, instance, created, raw, **kwargs):
+    if raw:
+        return
+    name = sender.__name__
+    if name in cached_model_names:
+        delay_cache = getattr(instance, '_delay_cache', False)
+        if not delay_cache:
+            from .tasks import update_cache_for_instance
+            update_cache_for_instance(name, instance.pk, instance)
+
+
+#
+# New user signals
+#
+@receiver(
+    post_save, sender=settings.AUTH_USER_MODEL,
+    dispatch_uid='add_user_to_change_resource_group')
+def add_user_to_change_resource_group(
+        signal, sender, instance, created, raw, **kwargs):
+    if created and not raw:
+        from django.contrib.auth.models import Group
+        instance.groups.add(Group.objects.get(name='change-resource'))
+        if hasattr(instance, 'group_names'):
+            del instance.group_names
+        post_save_update_cache(sender, instance, created, raw, **kwargs)

--- a/webplatformcompat/signals.py
+++ b/webplatformcompat/signals.py
@@ -3,20 +3,9 @@
 
 from __future__ import unicode_literals
 
-from django.conf import settings
-from django.db.models.signals import post_delete, post_save, m2m_changed
-from django.dispatch import receiver
-
 from .models import Feature, Section
 
-cached_model_names = (
-    'Browser', 'Feature', 'Maturity', 'Section', 'Specification',
-    'Support', 'Version', 'User')
 
-
-@receiver(
-    m2m_changed, sender=Feature.sections.through,
-    dispatch_uid='m2m_changed_feature_section')
 def feature_sections_changed_update_order(
         sender, instance, action, reverse, model, pk_set, **kwargs):
     """Maintain feature.section_order."""
@@ -49,39 +38,30 @@ def feature_sections_changed_update_order(
         update_cache_for_instance('Section', section.pk, section)
 
 
-@receiver(post_delete, dispatch_uid='post_delete_update_cache')
 def post_delete_update_cache(sender, instance, **kwargs):
+    """Invalidate the cache when an instance is deleted."""
     name = sender.__name__
-    if name in cached_model_names:
-        delay_cache = getattr(instance, '_delay_cache', False)
-        if not delay_cache:
-            from .tasks import update_cache_for_instance
-            update_cache_for_instance(name, instance.pk, instance)
+    delay_cache = getattr(instance, '_delay_cache', False)
+    if not delay_cache:
+        from .tasks import update_cache_for_instance
+        update_cache_for_instance(name, instance.pk, instance)
 
 
-@receiver(post_save, dispatch_uid='post_save_update_cache')
 def post_save_update_cache(sender, instance, created, raw, **kwargs):
+    """Invalidate the cache when an instance is created or updated."""
     if raw:
         return
     name = sender.__name__
-    if name in cached_model_names:
-        delay_cache = getattr(instance, '_delay_cache', False)
-        if not delay_cache:
-            from .tasks import update_cache_for_instance
-            update_cache_for_instance(name, instance.pk, instance)
+    delay_cache = getattr(instance, '_delay_cache', False)
+    if not delay_cache:
+        from .tasks import update_cache_for_instance
+        update_cache_for_instance(name, instance.pk, instance)
 
 
-#
-# New user signals
-#
-@receiver(
-    post_save, sender=settings.AUTH_USER_MODEL,
-    dispatch_uid='add_user_to_change_resource_group')
 def add_user_to_change_resource_group(
         signal, sender, instance, created, raw, **kwargs):
+    """Add change-resource permission to new users."""
     if created and not raw:
         from django.contrib.auth.models import Group
         instance.groups.add(Group.objects.get(name='change-resource'))
-        if hasattr(instance, 'group_names'):
-            del instance.group_names
         post_save_update_cache(sender, instance, created, raw, **kwargs)

--- a/webplatformcompat/signals.py
+++ b/webplatformcompat/signals.py
@@ -55,6 +55,13 @@ def post_delete_update_cache(sender, instance, **kwargs):
         update_cache_for_instance(name, instance.pk, instance)
 
 
+def post_save_changeset(sender, instance, created, raw, **kwargs):
+    """Invalidate the user cache after a changeset is created."""
+    if raw or not created:
+        return
+    update_cache_for_instance('User', instance.user.pk, instance.user)
+
+
 def post_save_update_cache(sender, instance, created, raw, **kwargs):
     """Invalidate the cache when an instance is created or updated."""
     if raw:

--- a/webplatformcompat/signals.py
+++ b/webplatformcompat/signals.py
@@ -6,6 +6,14 @@ from __future__ import unicode_literals
 from .models import Feature, Section
 
 
+def add_user_to_change_resource_group(
+        signal, sender, instance, created, raw, **kwargs):
+    """Add change-resource permission to new users."""
+    if created and not raw:
+        from django.contrib.auth.models import Group
+        instance.groups.add(Group.objects.get(name='change-resource'))
+
+
 def feature_sections_changed_update_order(
         sender, instance, action, reverse, model, pk_set, **kwargs):
     """Maintain feature.section_order."""
@@ -58,11 +66,3 @@ def post_save_update_cache(sender, instance, created, raw, **kwargs):
     if not delay_cache:
         from .tasks import update_cache_for_instance
         update_cache_for_instance(name, instance.pk, instance)
-
-
-def add_user_to_change_resource_group(
-        signal, sender, instance, created, raw, **kwargs):
-    """Add change-resource permission to new users."""
-    if created and not raw:
-        from django.contrib.auth.models import Group
-        instance.groups.add(Group.objects.get(name='change-resource'))

--- a/webplatformcompat/signals.py
+++ b/webplatformcompat/signals.py
@@ -52,6 +52,8 @@ def post_save_update_cache(sender, instance, created, raw, **kwargs):
     if raw:
         return
     name = sender.__name__
+    if name == 'User' and created:
+        return
     delay_cache = getattr(instance, '_delay_cache', False)
     if not delay_cache:
         from .tasks import update_cache_for_instance
@@ -64,4 +66,3 @@ def add_user_to_change_resource_group(
     if created and not raw:
         from django.contrib.auth.models import Group
         instance.groups.add(Group.objects.get(name='change-resource'))
-        post_save_update_cache(sender, instance, created, raw, **kwargs)

--- a/webplatformcompat/signals.py
+++ b/webplatformcompat/signals.py
@@ -3,14 +3,16 @@
 
 from __future__ import unicode_literals
 
+from django.contrib.auth.models import Group
+
 from .models import Feature, Section
+from .tasks import update_cache_for_instance
 
 
 def add_user_to_change_resource_group(
         signal, sender, instance, created, raw, **kwargs):
     """Add change-resource permission to new users."""
     if created and not raw:
-        from django.contrib.auth.models import Group
         instance.groups.add(Group.objects.get(name='change-resource'))
 
 
@@ -39,7 +41,6 @@ def feature_sections_changed_update_order(
             features = []
         sections = [instance]
 
-    from .tasks import update_cache_for_instance
     for feature in features:
         update_cache_for_instance('Feature', feature.pk, feature)
     for section in sections:
@@ -51,7 +52,6 @@ def post_delete_update_cache(sender, instance, **kwargs):
     name = sender.__name__
     delay_cache = getattr(instance, '_delay_cache', False)
     if not delay_cache:
-        from .tasks import update_cache_for_instance
         update_cache_for_instance(name, instance.pk, instance)
 
 
@@ -64,5 +64,4 @@ def post_save_update_cache(sender, instance, created, raw, **kwargs):
         return
     delay_cache = getattr(instance, '_delay_cache', False)
     if not delay_cache:
-        from .tasks import update_cache_for_instance
         update_cache_for_instance(name, instance.pk, instance)

--- a/webplatformcompat/tests/test_models.py
+++ b/webplatformcompat/tests/test_models.py
@@ -22,7 +22,7 @@ class TestManager(TestCase):
         self.mocked_get_history_changeset = self.patcher1.start()
         self.mocked_get_history_changeset.return_value = changeset
         self.patcher2 = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
+            'webplatformcompat.signals.update_cache_for_instance')
         self.mocked_update_cache = self.patcher2.start()
 
     def tearDown(self):

--- a/webplatformcompat/tests/test_models.py
+++ b/webplatformcompat/tests/test_models.py
@@ -8,8 +8,7 @@ from django.core.exceptions import ValidationError
 
 from webplatformcompat.history import Changeset
 from webplatformcompat.models import (
-    Browser, Feature, Maturity, Section, Specification, Support, Version,
-    post_save_update_cache)
+    Browser, Feature, Maturity, Section, Specification, Support, Version)
 from .base import TestCase
 
 
@@ -145,96 +144,3 @@ class TestVersion(TestCase):
         browser = Browser(slug='browser')
         version = Version(version='text', browser=browser)
         self.assertRaises(ValidationError, version.clean)
-
-
-class TestSaveSignal(unittest.TestCase):
-    def setUp(self):
-        self.patcher = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
-        self.mocked_update_cache = self.patcher.start()
-        self.browser = Browser(id=666)
-
-    def tearDown(self):
-        self.patcher.stop()
-
-    def test_raw(self):
-        post_save_update_cache(Browser, self.browser, created=True, raw=True)
-        self.mocked_update_cache.assert_not_called()
-
-    def test_create(self):
-        post_save_update_cache(Browser, self.browser, created=True, raw=False)
-        self.mocked_update_cache.assert_called_once_with(
-            'Browser', 666, self.browser)
-
-    def test_create_delayed(self):
-        self.browser._delay_cache = True
-        post_save_update_cache(Browser, self.browser, created=True, raw=False)
-        self.mocked_update_cache.assert_not_called()
-
-
-class TestM2MChangedSignal(TestCase):
-    def setUp(self):
-        patcher = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
-        self.login_user()
-        self.mocked_update_cache = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.maturity = self.create(Maturity, slug='foo')
-        self.specification = self.create(Specification, maturity=self.maturity)
-        self.section = self.create(Section, specification=self.specification)
-        self.feature = self.create(Feature)
-        self.mocked_update_cache.reset_mock()
-
-    def tearDown(self):
-        self.section.delete()
-        self.specification.delete()
-        self.maturity.delete()
-        self.feature.delete()
-
-    def test_add_section_to_feature(self):
-        self.feature.sections.add(self.section)
-        self.mocked_update_cache.assert_has_calls([
-            mock.call('Feature', self.feature.pk, self.feature),
-            mock.call('Section', self.section.pk, self.section)])
-        self.assertEqual(self.mocked_update_cache.call_count, 2)
-
-    def test_add_section_to_feature_delayed(self):
-        self.feature._delay_cache = True
-        self.feature.sections.add(self.section)
-        self.mocked_update_cache.assert_not_called()
-
-    def test_add_feature_to_section(self):
-        self.section.features.add(self.feature)
-        self.mocked_update_cache.assert_has_calls([
-            mock.call('Feature', self.feature.pk, self.feature),
-            mock.call('Section', self.section.pk, self.section)])
-        self.assertEqual(self.mocked_update_cache.call_count, 2)
-
-    def test_clear_features_from_section(self):
-        self.section.features.add(self.feature)
-        self.mocked_update_cache.reset_mock()
-        self.section.features.clear()
-        self.mocked_update_cache.assert_called_once_with(
-            'Section', self.section.pk, self.section)
-
-
-class TestDeleteSignal(TestCase):
-    def setUp(self):
-        patcher = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
-        self.login_user()
-        self.mocked_update_cache = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.maturity = self.create(Maturity, slug='foo')
-        self.mocked_update_cache.reset_mock()
-
-    def test_delete(self):
-        pk = self.maturity.pk
-        self.maturity.delete()
-        self.mocked_update_cache.assert_called_once_with(
-            'Maturity', pk, self.maturity)
-
-    def test_delete_delayed(self):
-        self.maturity._delay_cache = True
-        self.maturity.delete()
-        self.mocked_update_cache.assert_not_called()

--- a/webplatformcompat/tests/test_signals.py
+++ b/webplatformcompat/tests/test_signals.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Tests for API signal handlers."""
+import mock
+import unittest
+
+from webplatformcompat.models import (
+    Browser, Feature, Maturity, Section, Specification)
+from webplatformcompat.signals import post_save_update_cache
+from .base import TestCase
+
+
+class TestSaveSignal(unittest.TestCase):
+    def setUp(self):
+        self.patcher = mock.patch(
+            'webplatformcompat.tasks.update_cache_for_instance')
+        self.mocked_update_cache = self.patcher.start()
+        self.browser = Browser(id=666)
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_raw(self):
+        post_save_update_cache(Browser, self.browser, created=True, raw=True)
+        self.mocked_update_cache.assert_not_called()
+
+    def test_create(self):
+        post_save_update_cache(Browser, self.browser, created=True, raw=False)
+        self.mocked_update_cache.assert_called_once_with(
+            'Browser', 666, self.browser)
+
+    def test_create_delayed(self):
+        self.browser._delay_cache = True
+        post_save_update_cache(Browser, self.browser, created=True, raw=False)
+        self.mocked_update_cache.assert_not_called()
+
+
+class TestM2MChangedSignal(TestCase):
+    def setUp(self):
+        patcher = mock.patch(
+            'webplatformcompat.tasks.update_cache_for_instance')
+        self.login_user()
+        self.mocked_update_cache = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.maturity = self.create(Maturity, slug='foo')
+        self.specification = self.create(Specification, maturity=self.maturity)
+        self.section = self.create(Section, specification=self.specification)
+        self.feature = self.create(Feature)
+        self.mocked_update_cache.reset_mock()
+
+    def tearDown(self):
+        self.section.delete()
+        self.specification.delete()
+        self.maturity.delete()
+        self.feature.delete()
+
+    def test_add_section_to_feature(self):
+        self.feature.sections.add(self.section)
+        self.mocked_update_cache.assert_has_calls([
+            mock.call('Feature', self.feature.pk, self.feature),
+            mock.call('Section', self.section.pk, self.section)])
+        self.assertEqual(self.mocked_update_cache.call_count, 2)
+
+    def test_add_section_to_feature_delayed(self):
+        self.feature._delay_cache = True
+        self.feature.sections.add(self.section)
+        self.mocked_update_cache.assert_not_called()
+
+    def test_add_feature_to_section(self):
+        self.section.features.add(self.feature)
+        self.mocked_update_cache.assert_has_calls([
+            mock.call('Feature', self.feature.pk, self.feature),
+            mock.call('Section', self.section.pk, self.section)])
+        self.assertEqual(self.mocked_update_cache.call_count, 2)
+
+    def test_clear_features_from_section(self):
+        self.section.features.add(self.feature)
+        self.mocked_update_cache.reset_mock()
+        self.section.features.clear()
+        self.mocked_update_cache.assert_called_once_with(
+            'Section', self.section.pk, self.section)
+
+
+class TestDeleteSignal(TestCase):
+    def setUp(self):
+        patcher = mock.patch(
+            'webplatformcompat.tasks.update_cache_for_instance')
+        self.login_user()
+        self.mocked_update_cache = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.maturity = self.create(Maturity, slug='foo')
+        self.mocked_update_cache.reset_mock()
+
+    def test_delete(self):
+        pk = self.maturity.pk
+        self.maturity.delete()
+        self.mocked_update_cache.assert_called_once_with(
+            'Maturity', pk, self.maturity)
+
+    def test_delete_delayed(self):
+        self.maturity._delay_cache = True
+        self.maturity.delete()
+        self.mocked_update_cache.assert_not_called()

--- a/webplatformcompat/tests/test_signals.py
+++ b/webplatformcompat/tests/test_signals.py
@@ -12,7 +12,7 @@ from .base import TestCase
 class TestDeleteSignal(TestCase):
     def setUp(self):
         patcher = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
+            'webplatformcompat.signals.update_cache_for_instance')
         self.login_user()
         self.mocked_update_cache = patcher.start()
         self.addCleanup(patcher.stop)
@@ -34,7 +34,7 @@ class TestDeleteSignal(TestCase):
 class TestM2MChangedSignal(TestCase):
     def setUp(self):
         patcher = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
+            'webplatformcompat.signals.update_cache_for_instance')
         self.login_user()
         self.mocked_update_cache = patcher.start()
         self.addCleanup(patcher.stop)
@@ -80,7 +80,7 @@ class TestM2MChangedSignal(TestCase):
 class TestSaveSignal(unittest.TestCase):
     def setUp(self):
         self.patcher = mock.patch(
-            'webplatformcompat.tasks.update_cache_for_instance')
+            'webplatformcompat.signals.update_cache_for_instance')
         self.mocked_update_cache = self.patcher.start()
         self.browser = Browser(id=666)
 

--- a/webplatformcompat/tests/v1/test_viewsets.py
+++ b/webplatformcompat/tests/v1/test_viewsets.py
@@ -197,7 +197,11 @@ class TestBrowserViewset(APITestCase):
             'versions': [],
         }
         self.assertDataEqual(response.data, expected_data)
-        mock_update.assert_called_once_with('Browser', browser.pk, browser)
+        mock_update.assert_has_calls([
+            mock.call('User', self.user.pk, mock.ANY),
+            mock.call('Browser', browser.pk, mock.ANY),
+        ])
+        self.assertEqual(mock_update.call_count, 2)
 
     @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_put_in_changeset(self, mock_update):
@@ -248,7 +252,11 @@ class TestBrowserViewset(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(204, response.status_code, response.content)
         self.assertFalse(Browser.objects.filter(pk=browser.pk).exists())
-        mock_update.assert_called_once_with('Browser', browser.pk, mock.ANY)
+        mock_update.assert_has_calls([
+            mock.call('User', self.user.pk, mock.ANY),
+            mock.call('Browser', browser.pk, mock.ANY),
+        ])
+        self.assertEqual(mock_update.call_count, 2)
 
     def test_delete_not_allowed(self):
         self.login_user()

--- a/webplatformcompat/tests/v1/test_viewsets.py
+++ b/webplatformcompat/tests/v1/test_viewsets.py
@@ -169,7 +169,7 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_put_as_json_api(self, mock_update):
         """If content is application/vnd.api+json, put is partial."""
         browser = self.create(
@@ -199,7 +199,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
         mock_update.assert_called_once_with('Browser', browser.pk, browser)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_put_in_changeset(self, mock_update):
         browser = self.create(
             Browser, slug='browser', name={'en': 'Old Name'})
@@ -239,7 +239,7 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_delete(self, mock_update):
         self.login_user(groups=['change-resource', 'delete-resource'])
         browser = self.create(Browser, slug='firesux', name={'en': 'Firesux'})
@@ -262,7 +262,7 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_delete_in_changeset(self, mock_update):
         self.login_user(groups=['change-resource', 'delete-resource'])
         browser = self.create(

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -388,7 +388,7 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_put_as_json_api(self, mock_update):
         """If content is application/vnd.api+json, put is partial."""
         browser = self.create(
@@ -422,7 +422,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
         mock_update.assert_called_once_with('Browser', browser.pk, browser)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_put_in_changeset(self, mock_update):
         browser = self.create(
             Browser, slug='browser', name={'en': 'Old Name'})
@@ -462,7 +462,7 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_delete(self, mock_update):
         self.login_user(groups=['change-resource', 'delete-resource'])
         browser = self.create(Browser, slug='firesux', name={'en': 'Firesux'})
@@ -485,7 +485,7 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
-    @mock.patch('webplatformcompat.tasks.update_cache_for_instance')
+    @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_delete_in_changeset(self, mock_update):
         self.login_user(groups=['change-resource', 'delete-resource'])
         browser = self.create(

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -420,7 +420,11 @@ class TestBrowserViewset(APITestCase):
             'versions': [],
         }
         self.assertDataEqual(response.data, expected_data)
-        mock_update.assert_called_once_with('Browser', browser.pk, browser)
+        mock_update.assert_has_calls([
+            mock.call('User', self.user.pk, mock.ANY),
+            mock.call('Browser', browser.pk, mock.ANY),
+        ])
+        self.assertEqual(mock_update.call_count, 2)
 
     @mock.patch('webplatformcompat.signals.update_cache_for_instance')
     def test_put_in_changeset(self, mock_update):
@@ -471,7 +475,11 @@ class TestBrowserViewset(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(204, response.status_code, response.content)
         self.assertFalse(Browser.objects.filter(pk=browser.pk).exists())
-        mock_update.assert_called_once_with('Browser', browser.pk, mock.ANY)
+        mock_update.assert_has_calls([
+            mock.call('User', self.user.pk, mock.ANY),
+            mock.call('Browser', browser.pk, mock.ANY),
+        ])
+        self.assertEqual(mock_update.call_count, 2)
 
     def test_delete_not_allowed(self):
         self.login_user()


### PR DESCRIPTION
Refactor signals from models.py into signals.py, and be more explicit about signal registration order and associated models. Then, add a new signal to invalidate the user's instance cache when a new changeset is created, so that it will immediately be added to the relationship section. This changes a handful of integration tests.