### PR TITLE
fix bug 1250976 - Redirect to slashless API URLs

### DIFF
--- a/webplatformcompat/routers.py
+++ b/webplatformcompat/routers.py
@@ -92,8 +92,10 @@ class GroupedRouter(DefaultRouter):
 
                 # Add redirects to remove slashes
                 no_slash_pattern = regex.replace('$', '/$')
+                pattern_name = '%s:%s' % (self.version, name)
                 view = RedirectView.as_view(
-                    pattern_name=name, permanent=False, query_string=True)
+                    pattern_name=pattern_name, permanent=True,
+                    query_string=True)
                 urls.append(url(no_slash_pattern, view))
 
                 # Add endpoints that include the format as an extension


### PR DESCRIPTION
301 redirect [/api/v1/browsers/](http://browsercompat.herokuapp.com/api/v1/browsers/) to [/api/v1/browsers](http://browsercompat.herokuapp.com/api/v1/browsers). This worked (with a 302 redirect) before the switch to namespaced v1/v2 API URLs, but gives currently gives 410 Gone.