### PR TITLE
bug 1216786 - Prepare database for references

### DIFF
--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -217,7 +217,7 @@ fi
 
 # Create an empty database
 rm -f $DATABASE_NAME
-python manage.py migrate --verbosity=$VERBOSITY
+python manage.py migrate --verbosity=$VERBOSITY --noinput
 
 # Add the documentation user
 create_user $DOC_USER_NAME $DOC_USER_EMAIL $DOC_USER_PASSWORD 0

--- a/webplatformcompat/migrations/0018_add_resources_table.py
+++ b/webplatformcompat/migrations/0018_add_resources_table.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django_extensions.db.fields.json
+import webplatformcompat.validators
+import webplatformcompat.fields
+import webplatformcompat.models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('webplatformcompat', '0017_add_historical_orders'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='HistoricalReference',
+            fields=[
+                ('id', models.IntegerField(blank=True, verbose_name='ID', db_index=True, auto_created=True)),
+                ('note', webplatformcompat.fields.TranslatedField(blank=True, help_text='Notes for this section', validators=[webplatformcompat.validators.LanguageDictValidator(False)])),
+                ('_order', models.IntegerField(editable=False)),
+                ('history_id', models.AutoField(serialize=False, primary_key=True)),
+                ('history_date', models.DateTimeField()),
+                ('history_type', models.CharField(max_length=1, choices=[('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')])),
+                ('feature', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, null=True, blank=True, to='webplatformcompat.Feature', related_name='+', db_constraint=False)),
+                ('history_changeset', models.ForeignKey(to='webplatformcompat.Changeset', related_name='historical_references')),
+                ('history_user', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, null=True, to=settings.AUTH_USER_MODEL, related_name='+')),
+                ('section', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, null=True, blank=True, to='webplatformcompat.Section', related_name='+', db_constraint=False)),
+            ],
+            options={
+                'verbose_name': 'historical reference',
+                'ordering': ('-history_date', '-history_id'),
+                'get_latest_by': 'history_date',
+            },
+        ),
+        migrations.CreateModel(
+            name='Reference',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('note', webplatformcompat.fields.TranslatedField(blank=True, help_text='Notes for this section', validators=[webplatformcompat.validators.LanguageDictValidator(False)])),
+                ('feature', models.ForeignKey(to='webplatformcompat.Feature', related_name='references')),
+                ('section', models.ForeignKey(to='webplatformcompat.Section', related_name='references')),
+            ],
+            bases=(webplatformcompat.models.HistoryMixin, models.Model),
+        ),
+        migrations.AddField(
+            model_name='historicalfeature',
+            name='references',
+            field=django_extensions.db.fields.json.JSONField(null=True, default='[]'),
+        ),
+        migrations.AlterField(
+            model_name='historicalfeature',
+            name='sections',
+            field=django_extensions.db.fields.json.JSONField(null=True, default='[]'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='reference',
+            unique_together=set([('feature', 'section')]),
+        ),
+        migrations.AlterOrderWithRespectTo(
+            name='reference',
+            order_with_respect_to='feature',
+        ),
+        migrations.AlterField(
+            model_name='changeset',
+            name='target_resource_type',
+            field=models.CharField(max_length=12, blank=True, help_text='Type of target resource', choices=[('browsers', 'browsers'), ('features', 'features'), ('maturities', 'maturities'), ('references', 'references'), ('sections', 'sections'), ('specifications', 'specifications'), ('supports', 'supports'), ('versions', 'versions')]),
+        ),
+        migrations.AlterField(
+            model_name='historicalsection',
+            name='note',
+            field=webplatformcompat.fields.TranslatedField(help_text='Notes for this section', blank=True, null=True, validators=[webplatformcompat.validators.LanguageDictValidator(False)]),
+        ),
+        migrations.AlterField(
+            model_name='section',
+            name='note',
+            field=webplatformcompat.fields.TranslatedField(help_text='Notes for this section', blank=True, null=True, validators=[webplatformcompat.validators.LanguageDictValidator(False)]),
+        ),
+    ]

--- a/webplatformcompat/migrations/0019_add_reference_permissions.py
+++ b/webplatformcompat/migrations/0019_add_reference_permissions.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Add API permissions for reference instances."""
+from __future__ import unicode_literals
+from itertools import chain
+
+from django.db import migrations
+
+group_perms = {
+    'change-resource': [
+        'add_reference',
+        'change_reference',
+    ],
+    'delete-resource': [
+        'delete_reference',
+    ]
+}
+
+
+def add_permissions(apps, schema_editor, with_create_permissions=True):
+    """Add resource permissions to API groups."""
+    Group = apps.get_model('auth', 'Group')
+    Permission = apps.get_model('auth', 'Permission')
+    try:
+        perms = dict(
+            [(codename, Permission.objects.get(codename=codename))
+             for codename in set(chain(*group_perms.values()))])
+    except Permission.DoesNotExist:
+        if with_create_permissions:
+            # create_permissions runs in the post_migrate signal, at the end of
+            # all migrations. If migrating a fresh database (such as during
+            # tests), then manually run create_permissions.
+            from django.contrib.auth.management import create_permissions
+            assert not getattr(apps, 'models_module', None)
+            apps.models_module = True
+            create_permissions(apps, verbosity=0)
+            apps.models_module = None
+            return add_permissions(
+                apps, schema_editor, with_create_permissions=False)
+        else:
+            raise
+
+    for group_name in sorted(group_perms.keys()):
+        group = Group.objects.get(name=group_name)
+        perm_list = [
+            perms[codename] for codename in group_perms[group_name]]
+        group.permissions.add(*perm_list)
+
+
+def drop_permissions(apps, schema_editor):
+    """Drop References permissions."""
+    Group = apps.get_model('auth', 'Group')
+    Permission = apps.get_model('auth', 'Permission')
+
+    perms = dict()
+    for codename in set(chain(*group_perms.values())):
+        try:
+            permission = Permission.objects.get(codename=codename)
+        except Permission.DoesNotExist:
+            pass
+        else:
+            perms[codename] = permission
+
+    for group_name in sorted(group_perms.keys()):
+        group = Group.objects.get(name=group_name)
+        perm_list = [
+            perms[codename] for codename in group_perms[group_name]]
+        group.permissions.remove(*perm_list)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0018_add_resources_table'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_permissions, drop_permissions)
+    ]


### PR DESCRIPTION
Add the references table and related resources, but without the related Django model changes. Also add API permissions for the new references instances.

This PR needs to be applied in production before merging code that uses the new table. This PR is step 1 of 3:

* [Step 2](https://github.com/mdn/browsercompat/tree/references_step2_1216786): Switch code to use references instead of feature/section M2M relationship
* [Step 3](https://github.com/mdn/browsercompat/tree/references_step3_1216786): Drop unused database data