### PR TITLE
fix bug 1216786 - Cleanup transition to references

### DIFF
--- a/requirements/application.txt
+++ b/requirements/application.txt
@@ -71,6 +71,7 @@ django-mptt==0.8.0 \
     --hash=sha256:4cd88980f3d66ec021f9cdafcaa92d9f831b5f397679ac40302159d69eaef17a
 
 # Sorted ManyToManyField
+# No longer used, but present in webplatformcompat/migrations/0001_initial.py
 django-sortedm2m==1.1.1 \
     --hash=sha256:d38d201da8593c94c8706f9ef30e3203bf0d352d6264abbb7babfbb112f86cb4
 

--- a/webplatformcompat/migrations/0021_drop_feature_section_m2m.py
+++ b/webplatformcompat/migrations/0021_drop_feature_section_m2m.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django_extensions.db.fields.json
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0020_populate_references'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='feature',
+            name='sections',
+        ),
+        migrations.RemoveField(
+            model_name='historicalfeature',
+            name='sections',
+        ),
+        migrations.RemoveField(
+            model_name='historicalsection',
+            name='note',
+        ),
+        migrations.RemoveField(
+            model_name='section',
+            name='note',
+        ),
+        migrations.AlterField(
+            model_name='historicalfeature',
+            name='references',
+            field=django_extensions.db.fields.json.JSONField(default='[]'),
+        ),
+    ]

--- a/webplatformcompat/models.py
+++ b/webplatformcompat/models.py
@@ -391,7 +391,7 @@ class HistoricalBrowserRecords(HistoricalRecords):
 
 class HistoricalFeatureRecords(HistoricalRecords):
     additional_fields = {
-        'references': JSONField(null=True, default=[]),
+        'references': JSONField(default=[]),
         'children': JSONField(default=[])
     }
 


### PR DESCRIPTION
* Drop M2M relation from features to sections
* Drop note from Section
* Disallow null references list in HistoricalFeatures

django-sortedm2m needs to be retained until migrations are squashed.