### PR TITLE
fix bug 1243221 - Reject query parameters reserved by JSON API v1.0

### DIFF
--- a/docs/v1/doc_cases.json
+++ b/docs/v1/doc_cases.json
@@ -90,7 +90,7 @@
     }, {
         "name": "browser-create-in-changeset-2",
         "method": "POST",
-        "endpoint": "browsers?changeset=4",
+        "endpoint": "browsers?use_changeset=4",
         "data": {
             "browsers": {
                 "slug": "nintendo-ds",
@@ -745,7 +745,7 @@
     }, {
         "name": "view-feature-update-parts-with-changeset-2",
         "method": "POST",
-        "endpoint": "versions?changeset=36",
+        "endpoint": "versions?use_changeset=36",
         "data": {
             "versions": {
                 "version": "2.0",
@@ -758,7 +758,7 @@
     }, {
         "name": "view-feature-update-parts-with-changeset-3",
         "method": "POST",
-        "endpoint": "supports?changeset=36",
+        "endpoint": "supports?use_changeset=36",
         "data": {
             "supports": {
                 "links": {

--- a/docs/v1/raw/browser-create-in-changeset-2-request-headers.txt
+++ b/docs/v1/raw/browser-create-in-changeset-2-request-headers.txt
@@ -1,4 +1,4 @@
-POST /api/v1/browsers?changeset=4 HTTP/1.1
+POST /api/v1/browsers?use_changeset=4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
 Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
@@ -1,4 +1,4 @@
-POST /api/v1/versions?changeset=36 HTTP/1.1
+POST /api/v1/versions?use_changeset=36 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
 Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v1/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
+++ b/docs/v1/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
@@ -1,4 +1,4 @@
-POST /api/v1/supports?changeset=36 HTTP/1.1
+POST /api/v1/supports?use_changeset=36 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
 Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v2/doc_cases.json
+++ b/docs/v2/doc_cases.json
@@ -141,7 +141,7 @@
     }, {
         "name": "browser-create-in-changeset-2",
         "method": "POST",
-        "endpoint": "browsers?changeset=4",
+        "endpoint": "browsers?use_changeset=4",
         "data": {
             "data": {
                 "type": "browsers",
@@ -1887,7 +1887,7 @@
     }, {
         "name": "view-feature-update-parts-with-changeset-2",
         "method": "POST",
-        "endpoint": "versions?changeset=55",
+        "endpoint": "versions?use_changeset=55",
         "data": {
             "data": {
                 "type": "versions",
@@ -1907,7 +1907,7 @@
     }, {
         "name": "view-feature-update-parts-with-changeset-3",
         "method": "POST",
-        "endpoint": "supports?changeset=55",
+        "endpoint": "supports?use_changeset=55",
         "data": {
             "data": {
                 "type": "supports",

--- a/docs/v2/implementation.rst
+++ b/docs/v2/implementation.rst
@@ -185,7 +185,7 @@ resources:
 .. literalinclude:: /v2/raw/browser-create-in-changeset-3-request-body.json
     :language: json
 
-The response included relationships to the items created in the changeset:
+The response includes relationships to the items created in the changeset:
 
 .. literalinclude:: /v2/raw/browser-create-in-changeset-3-response-headers.txt
     :language: http

--- a/docs/v2/raw/browser-create-in-changeset-2-request-headers.txt
+++ b/docs/v2/raw/browser-create-in-changeset-2-request-headers.txt
@@ -1,4 +1,4 @@
-POST /api/v2/browsers?changeset=4 HTTP/1.1
+POST /api/v2/browsers?use_changeset=4 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
 Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v2/raw/browser-create-in-changeset-2-response-body.json
+++ b/docs/v2/raw/browser-create-in-changeset-2-response-body.json
@@ -1,6 +1,6 @@
 {
     "links": {
-        "self": "https://browsercompat.org/api/v2/browsers?changeset=4"
+        "self": "https://browsercompat.org/api/v2/browsers?use_changeset=4"
     },
     "data": {
         "type": "browsers",

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-2-request-headers.txt
@@ -1,4 +1,4 @@
-POST /api/v2/versions?changeset=55 HTTP/1.1
+POST /api/v2/versions?use_changeset=55 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
 Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-2-response-body.json
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-2-response-body.json
@@ -1,6 +1,6 @@
 {
     "links": {
-        "self": "https://browsercompat.org/api/v2/versions?changeset=55"
+        "self": "https://browsercompat.org/api/v2/versions?use_changeset=55"
     },
     "data": {
         "type": "versions",

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-3-request-headers.txt
@@ -1,4 +1,4 @@
-POST /api/v2/supports?changeset=55 HTTP/1.1
+POST /api/v2/supports?use_changeset=55 HTTP/1.1
 Host: browsercompat.org
 Accept: application/vnd.api+json
 Authorization: Bearer xxQLNiTUFjRL5En8nBWzSDc5tLWkV2

--- a/docs/v2/raw/view-feature-update-parts-with-changeset-3-response-body.json
+++ b/docs/v2/raw/view-feature-update-parts-with-changeset-3-response-body.json
@@ -1,6 +1,6 @@
 {
     "links": {
-        "self": "https://browsercompat.org/api/v2/supports?changeset=55"
+        "self": "https://browsercompat.org/api/v2/supports?use_changeset=55"
     },
     "data": {
         "type": "supports",

--- a/tools/client.py
+++ b/tools/client.py
@@ -61,7 +61,7 @@ class Client(object):
         if method in change_methods and self.csrftoken:
             headers['X-CSRFToken'] = self.csrftoken
         if method in change_methods and self.changeset:
-            params['changeset'] = self.changeset
+            params['use_changeset'] = self.changeset
         if method in create_methods:
             expected_statuses = [201]
         elif method in delete_methods:

--- a/webplatformcompat/exceptions.py
+++ b/webplatformcompat/exceptions.py
@@ -44,5 +44,6 @@ def handler(exc, context):
     Otherwise, use the default Django REST Framework handler.
     """
     response = base_handler(exc, context)
-    response.exc = exc
+    if response is not None:
+        response.exc = exc
     return response

--- a/webplatformcompat/exceptions.py
+++ b/webplatformcompat/exceptions.py
@@ -25,6 +25,17 @@ class InvalidQueryParam(APIException):
         self.detail = self.detail_fmt % {'query_param': query_param}
 
 
+class NotImplementedQueryParam(InvalidQueryParam):
+    """Request contained an query parameter that is not implemented.
+
+    JSON API v1.0 requires a 400 when the service doesn't support a documented
+    query parameter, such as 'include':
+    http://jsonapi.org/format/1.0/#fetching-includes
+    """
+
+    detail_fmt = _('Query parameter "%(query_param)s" is not implemented.')
+
+
 def handler(exc, context):
     """
     Return the response that should be used for any given exception.

--- a/webplatformcompat/exceptions.py
+++ b/webplatformcompat/exceptions.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""API exceptions and exception handler."""
+
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.exceptions import APIException
+from rest_framework.status import HTTP_400_BAD_REQUEST
+from rest_framework.views import exception_handler as base_handler
+
+
+class InvalidQueryParam(APIException):
+    """The request contained a bad query parameter.
+
+    JSON API v1.0 defines a structure (source/parameter) for specifying which
+    query parameter was bad.
+    http://jsonapi.org/format/1.0/#error-objects
+    """
+
+    detail_fmt = _('Query parameter "%(query_param)s" is invalid.')
+    status_code = HTTP_400_BAD_REQUEST
+
+    def __init__(self, query_param):
+        """Initialize the exception with the bad query parameter."""
+        self.parameter = query_param
+        self.detail = self.detail_fmt % {'query_param': query_param}
+
+
+def handler(exc, context):
+    """
+    Return the response that should be used for any given exception.
+
+    If the v2 API is called, use the JSON API v1.0 exception handler.
+    Otherwise, use the default Django REST Framework handler.
+    """
+    response = base_handler(exc, context)
+    response.exc = exc
+    return response

--- a/webplatformcompat/history.py
+++ b/webplatformcompat/history.py
@@ -160,7 +160,7 @@ class HistoryChangesetMiddleware(BaseHistoryRequestMiddleware):
         # Default is to update cached objects as they are modified
         request.delay_cache = False
 
-        changeset_id = request.GET.get('changeset')
+        changeset_id = request.GET.get('use_changeset')
         if changeset_id:
             changeset = Changeset.objects.get(id=changeset_id)
             if changeset.user != request.user:

--- a/webplatformcompat/tests/test_exceptions.py
+++ b/webplatformcompat/tests/test_exceptions.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Tests for API exceptions."""
+
+from rest_framework.exceptions import ParseError
+
+from ..exceptions import handler
+from .base import TestCase
+
+
+class TestExceptionHandler(TestCase):
+    """Test the extended exception handler."""
+
+    def test_api_exception(self):
+        """Test the response includes 'standard' exceptions as an attribute."""
+        exception = ParseError()
+        response = handler(exception, {})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.exc, exception)
+
+    def test_unexpected_exception(self):
+        """Test that unexpected responses return None."""
+        response = handler(ValueError('unexpected'), {})
+        self.assertIsNone(response)

--- a/webplatformcompat/tests/test_history.py
+++ b/webplatformcompat/tests/test_history.py
@@ -26,7 +26,7 @@ class TestBaseMiddleware(APITestCase):
         """Return the test URL."""
         return (
             self.api_reverse('browser-list') +
-            '?changeset=%s' % changeset.id)
+            '?use_changeset=%s' % changeset.id)
 
     def test_post_with_changeset(self):
         self.login_user()

--- a/webplatformcompat/tests/test_history.py
+++ b/webplatformcompat/tests/test_history.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for simple_history extensions."""
 
-from json import loads
+from json import dumps, loads
 
 from django.contrib.auth.models import User
 
@@ -11,17 +11,29 @@ from webplatformcompat.models import Browser
 from .base import APITestCase
 
 
-class TestMiddleware(APITestCase):
-    """Test the HistoryChangesetRequestMiddleware."""
+class TestBaseMiddleware(APITestCase):
+    """Test the HistoryChangesetRequestMiddleware.
+
+    This should be tested by a subclass that defines:
+    * namespace - the API namespace, such as v1
+    * api_data - A function returning data in the API format
+    """
 
     __test__ = False  # Don't test outside of a versioned API
+    content_type = 'application/vnd.api+json'
+
+    def url(self, changeset):
+        """Return the test URL."""
+        return (
+            self.api_reverse('browser-list') +
+            '?changeset=%s' % changeset.id)
 
     def test_post_with_changeset(self):
         self.login_user()
         changeset = Changeset.objects.create(user=self.user)
-        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
-        data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
-        response = self.client.post(url, data)
+        url = self.url(changeset)
+        response = self.client.post(
+            url, dumps(self.api_data()), content_type=self.content_type)
         self.assertEqual(201, response.status_code, response.data)
         browser = Browser.objects.get()
         history = browser.history.get()
@@ -31,10 +43,9 @@ class TestMiddleware(APITestCase):
         self.login_user()
         other = User.objects.create(username='other')
         changeset = Changeset.objects.create(user=other)
-        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
-        data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
+        url = self.url(changeset)
         response = self.client.post(
-            url, data, content_type='application/vnd.api+json')
+            url, dumps(self.api_data()), content_type=self.content_type)
         self.assertEqual(400, response.status_code)
         expected = {
             'errors': {
@@ -47,10 +58,9 @@ class TestMiddleware(APITestCase):
     def test_post_with_closed_changeset(self):
         self.login_user()
         changeset = Changeset.objects.create(user=self.user, closed=True)
-        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
-        data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
+        url = self.url(changeset)
         response = self.client.post(
-            url, data, content_type='application/vnd.api+json')
+            url, dumps(self.api_data()), content_type=self.content_type)
         self.assertEqual(400, response.status_code)
         expected = {
             'errors': {
@@ -60,7 +70,7 @@ class TestMiddleware(APITestCase):
     def test_post_with_error_not_json_api(self):
         self.login_user()
         changeset = Changeset.objects.create(user=self.user, closed=True)
-        url = self.api_reverse('browser-list') + '?changeset=%s' % changeset.id
+        url = self.url(changeset)
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
         response = self.client.post(url, data)
         self.assertEqual(400, response.status_code)

--- a/webplatformcompat/tests/v1/test_history.py
+++ b/webplatformcompat/tests/v1/test_history.py
@@ -1,11 +1,20 @@
 # -*- coding: utf-8 -*-
 """Tests for simple history overrides in v1 API."""
 
-from ..test_history import TestMiddleware
+from ..test_history import TestBaseMiddleware
+from .base import NamespaceMixin
 
 
-class TestMiddlewareInV1(TestMiddleware):
+class TestMiddleware(NamespaceMixin, TestBaseMiddleware):
     """Test the Middleware using v1 API endpoints."""
 
-    __test__ = True  # Run these tests
-    namespace = 'v1'  # Use the v1 API endpoints
+    def api_data(self):
+        """Return JSON data for creating a new browser."""
+        return {
+            'browsers': {
+                'slug': 'firefox',
+                'name': {
+                    'en': 'Firefox'
+                }
+            }
+        }

--- a/webplatformcompat/tests/v1/test_viewsets.py
+++ b/webplatformcompat/tests/v1/test_viewsets.py
@@ -216,7 +216,7 @@ class TestBrowserViewset(APITestCase):
             }
         })
         url = self.api_reverse('browser-detail', pk=browser.pk)
-        url += '?changeset=%s' % changeset.pk
+        url += '?use_changeset=%s' % changeset.pk
         mock_update.reset_mock()
         mock_update.side_effect = Exception('not called')
         response = self.client.put(
@@ -277,7 +277,7 @@ class TestBrowserViewset(APITestCase):
             Browser, slug='internet_exploder',
             name={'en': 'Internet Exploder'})
         url = self.api_reverse('browser-detail', pk=browser.pk)
-        url += '?changeset=%d' % self.changeset.id
+        url += '?use_changeset=%d' % self.changeset.id
         mock_update.reset_mock()
         mock_update.side_effect = Exception('not called')
         response = self.client.delete(url)

--- a/webplatformcompat/tests/v2/test_history.py
+++ b/webplatformcompat/tests/v2/test_history.py
@@ -1,9 +1,23 @@
 # -*- coding: utf-8 -*-
 """Tests for simple history overrides in v2 API."""
 
-from ..test_history import TestMiddleware
+from ..test_history import TestBaseMiddleware
 from .base import NamespaceMixin
 
 
-class TestMiddlewareInV2(TestMiddleware, NamespaceMixin):
-    """Test the Middleware using API endpoints."""
+class TestMiddleware(NamespaceMixin, TestBaseMiddleware):
+    """Test the Middleware using v2 API endpoints."""
+
+    def api_data(self):
+        """Return JSON data for creating a new browser."""
+        return {
+            'data': {
+                'type': 'browsers',
+                'attributes': {
+                    'slug': 'firefox',
+                    'name': {
+                        'en': 'Firefox'
+                    }
+                }
+            }
+        }

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -556,6 +556,28 @@ class TestBrowserViewset(APITestCase):
         self.assertEqual(200, response.status_code, response.content)
         self.assertEqual(5, response.data['count'])
 
+    def assert_param_not_implemented(self, key, value):
+        """Assert that a valid but optional parameter is not implemented."""
+        url = self.api_reverse('browser-list')
+        response = self.client.get(url, {key: value})
+        self.assertEqual(400, response.status_code, response.content)
+        expected = {
+            'errors': [{
+                'status': '400',
+                'detail': 'Query parameter "%s" is not implemented.' % key,
+                'source': {'parameter': key}
+            }]
+        }
+        self.assertEqual(expected, loads(response.content.decode('utf8')))
+
+    def test_param_include_not_implemented(self):
+        """
+        Confirm parameter include is unimplemented.
+
+        TODO: bug 1243190, use param 'include' for included resources.
+        """
+        self.assert_param_not_implemented('include', 'versions')
+
 
 class TestFeatureViewSet(APITestCase):
     """Test FeatureViewSet."""

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -578,6 +578,15 @@ class TestBrowserViewset(APITestCase):
         """
         self.assert_param_not_implemented('include', 'versions')
 
+    def test_param_fields_unimplemented(self):
+        """
+        Confirm JSON API v1.0 parameter 'fields' is unimplemented.
+
+        TODO: bug 1252973, use param 'fields' for sparse fieldsets.
+        """
+        self.assert_param_not_implemented('fields', 'name')
+        self.assert_param_not_implemented('fields[browsers]', 'slug,name')
+
 
 class TestFeatureViewSet(APITestCase):
     """Test FeatureViewSet."""

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -439,7 +439,7 @@ class TestBrowserViewset(APITestCase):
             }
         })
         url = self.api_reverse('browser-detail', pk=browser.pk)
-        url += '?changeset=%s' % changeset.pk
+        url += '?use_changeset=%s' % changeset.pk
         mock_update.reset_mock()
         mock_update.side_effect = Exception('not called')
         response = self.client.put(
@@ -500,7 +500,7 @@ class TestBrowserViewset(APITestCase):
             Browser, slug='internet_exploder',
             name={'en': 'Internet Exploder'})
         url = self.api_reverse('browser-detail', pk=browser.pk)
-        url += '?changeset=%d' % self.changeset.id
+        url += '?use_changeset=%d' % self.changeset.id
         mock_update.reset_mock()
         mock_update.side_effect = Exception('not called')
         response = self.client.delete(url)

--- a/webplatformcompat/tests/v2/test_viewsets.py
+++ b/webplatformcompat/tests/v2/test_viewsets.py
@@ -587,6 +587,14 @@ class TestBrowserViewset(APITestCase):
         self.assert_param_not_implemented('fields', 'name')
         self.assert_param_not_implemented('fields[browsers]', 'slug,name')
 
+    def test_param_sort_unimplemented(self):
+        """
+        Confirm JSON API v1.0 parameter 'sort' is unimplemented.
+
+        TODO: bug 1252973, use param 'fields' for sparse fieldsets.
+        """
+        self.assert_param_not_implemented('sort', 'name')
+
 
 class TestFeatureViewSet(APITestCase):
     """Test FeatureViewSet."""

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -138,6 +138,9 @@ class RelatedActionMixin(object):
         elif key == 'include':
             # TODO: bug 1243190, implement included resources
             raise NotImplementedQueryParam(key)
+        elif key == 'fields' or key.startswith('fields['):
+            # TODO: bug 1252973, implement sparse fieldsets
+            raise NotImplementedQueryParam(key)
         elif key == 'changeset':
             # TODO: bug 1243221, change to JSON API v1.0 valid keyword
             pass

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -11,7 +11,7 @@ from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.response import Response
 
-from ..exceptions import InvalidQueryParam
+from ..exceptions import InvalidQueryParam, NotImplementedQueryParam
 from ..renderers import BrowsableAPIRenderer
 from ..viewsets import (
     BrowserBaseViewSet, ChangesetBaseViewSet, FeatureBaseViewSet,
@@ -54,6 +54,7 @@ class RelatedActionMixin(object):
     # View parameter set by related_list
     related_filter = None
     filter_re = re.compile('^filter\[(?P<name>[^]]*)\]$')
+    reserved_param_re = re.compile('^[a-z]*$')
 
     # Other parameters
     reserved_param_re = re.compile('^[a-z]*$')
@@ -134,6 +135,9 @@ class RelatedActionMixin(object):
             # Pagination is handled in .pagination.Pagination class
             # TOOD: bug 1243128, use page[number] and page[size]
             pass
+        elif key == 'include':
+            # TODO: bug 1243190, implement included resources
+            raise NotImplementedQueryParam(key)
         elif key == 'changeset':
             # TODO: bug 1243221, change to JSON API v1.0 valid keyword
             pass

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -144,9 +144,6 @@ class RelatedActionMixin(object):
         elif key == 'sort':
             # TODO: bug 1243195, implement sorting
             raise NotImplementedQueryParam(key)
-        elif key == 'changeset':
-            # TODO: bug 1243221, change to JSON API v1.0 valid keyword
-            pass
         elif self.reserved_param_re.match(key):
             raise InvalidQueryParam(key)
 

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -11,6 +11,7 @@ from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.response import Response
 
+from ..exceptions import InvalidQueryParam
 from ..renderers import BrowsableAPIRenderer
 from ..viewsets import (
     BrowserBaseViewSet, ChangesetBaseViewSet, FeatureBaseViewSet,
@@ -52,8 +53,10 @@ class RelatedActionMixin(object):
 
     # View parameter set by related_list
     related_filter = None
-
     filter_re = re.compile('^filter\[(?P<name>[^]]*)\]$')
+
+    # Other parameters
+    reserved_param_re = re.compile('^[a-z]*$')
 
     def add_related_context(self, context):
         """Add related data to a context dictionary."""
@@ -117,11 +120,25 @@ class RelatedActionMixin(object):
                     # Treat blank link values as None
                     value = None
                 filters[name] = value
+            else:
+                self.verify_parameter(key)
 
         # Apply the implicit filter for related views
         filters.update(getattr(self, 'related_filter') or {})
 
         return filters
+
+    def verify_parameter(self, key):
+        """Raise an error for invalid query parameters."""
+        if key in ('page', 'page_size'):
+            # Pagination is handled in .pagination.Pagination class
+            # TOOD: bug 1243128, use page[number] and page[size]
+            pass
+        elif key == 'changeset':
+            # TODO: bug 1243221, change to JSON API v1.0 valid keyword
+            pass
+        elif self.reserved_param_re.match(key):
+            raise InvalidQueryParam(key)
 
     def related_item(self, request, pk):
         """Return a related item, or signal that there is no related item."""

--- a/webplatformcompat/v2/viewsets.py
+++ b/webplatformcompat/v2/viewsets.py
@@ -141,6 +141,9 @@ class RelatedActionMixin(object):
         elif key == 'fields' or key.startswith('fields['):
             # TODO: bug 1252973, implement sparse fieldsets
             raise NotImplementedQueryParam(key)
+        elif key == 'sort':
+            # TODO: bug 1243195, implement sorting
+            raise NotImplementedQueryParam(key)
         elif key == 'changeset':
             # TODO: bug 1243221, change to JSON API v1.0 valid keyword
             pass

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -407,6 +407,7 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': config('PAGE_SIZE', default=10, cast=int),
     'DEFAULT_VERSIONING_CLASS': (
         'rest_framework.versioning.NamespaceVersioning'),
+    'EXCEPTION_HANDLER': 'webplatformcompat.exceptions.handler',
 }
 
 # Django nose


### PR DESCRIPTION
JSON API v1.0 requires that a 400 error is returned when certain query parameters are used. This includes parameters for unimplemented features (like [``include``](http://jsonapi.org/format/1.0/#fetching-includes)), as well as any all-lowercase query parameters (reserved for [future growth](http://jsonapi.org/format/1.0/#query-parameters)).

This PR adds query parameter verification, returning [correctly formatted error objects](http://jsonapi.org/format/1.0/#error-objects) for rejected parameters.

The existing parameter ``changeset`` is invalid under the JSON API v1.0 spec. It is used to perform related modifications under the same logical changeset. This PR changes the parameter to ``use_changeset``, which is reflected in unit test, tools, integration tests, and documentation.