### PR TITLE
[WIP] bug 1251252 - Allow empty section names

### DIFF
--- a/webplatformcompat/migrations/0022_sections_name_allow_blank.py
+++ b/webplatformcompat/migrations/0022_sections_name_allow_blank.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import webplatformcompat.validators
+import webplatformcompat.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0021_drop_feature_section_m2m'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='section',
+            name='name',
+            field=webplatformcompat.fields
+            .TranslatedField(help_text='Name of section, without section number'
+                             , validators=[webplatformcompat.validators
+                                           .LanguageDictValidator(False)],
+                             blank=True),
+        ),
+    ]
+

--- a/webplatformcompat/migrations/0022_sections_name_allow_blank.py
+++ b/webplatformcompat/migrations/0022_sections_name_allow_blank.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+#flake8: noqa
 from __future__ import unicode_literals
 
 from django.db import migrations, models

--- a/webplatformcompat/migrations/0022_sections_name_allow_blank.py
+++ b/webplatformcompat/migrations/0022_sections_name_allow_blank.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#flake8: noqa
+# flake8: noqa
 from __future__ import unicode_literals
 
 from django.db import migrations, models

--- a/webplatformcompat/migrations/0023_replace_blank_sections_name_by_empty.py
+++ b/webplatformcompat/migrations/0023_replace_blank_sections_name_by_empty.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from __future__ import unicode_literals
 
 from django.db import migrations, models

--- a/webplatformcompat/migrations/0023_replace_blank_sections_name_by_empty.py
+++ b/webplatformcompat/migrations/0023_replace_blank_sections_name_by_empty.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def blank_to_empty(apps, schema_editor):
+    Section = apps.get_model('webplatformcompat', 'section')
+    for section in Section.objects.filter(name__regex='^\s*$'):
+        section.name = None
+        section.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0022_sections_name_allow_blank'),
+    ]
+
+    operations = [
+        migrations.RunPython(blank_to_empty),
+    ]

--- a/webplatformcompat/models.py
+++ b/webplatformcompat/models.py
@@ -238,6 +238,10 @@ class Section(HistoryMixin, models.Model):
         blank=True)
     name = TranslatedField(
         help_text='Name of section, without section number')
+    # TODO Remove the line behold and uncomment the lines down this,
+    # once the PR is merged
+    # name = TranslatedField(
+    #    help_text='Name of section, without section number', blank=True)
     subpath = TranslatedField(
         help_text=(
             'A subpage (possible with an #anchor) to get to the subsection'


### PR DESCRIPTION
[WIP] bug 1251252 - Allow empty section names
- [x] Update the Django model to add blank=True
- [x] Apply the migration to the production database
- [x] Migrate blank names to empty 
- [ ] Update the v1 and v2 API documentation to mark it as optional
- [ ] Confirm the sample views can handle empty section names
- [ ] Update the MDN importer to treat omitted anchor names as omitted section names
