### PR TITLE
Cancelling the project

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,6 +2,8 @@
 Contributing
 ============
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 Contributions should follow the `MDN Contribution Guidelines`_, and follow the
 standards of this project:
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,15 +2,11 @@
 
 History
 -------
+The BrowserCompat API project has been cancelled. Here are some development
+milestones:
 
-The BrowserCompat API is still in beta, and true versioning won't start until
-it is shipped to the general public. The issues are tracked on Bugzilla_.
-
-When code is merged to master (once or twice a week), it is deployed to Heroku
-at https://browsercompat.herokuapp.com.
-
-Here are some development milestones:
-
+* 2017-04-24 - Begin the process of removing the beta integration
+* 2016-02-16 - Last code written
 * 2015-12-01 - MDN beta users can see API-backed tables on select pages
 * 2015-09-11 - 3rd re-write of MDN importer ships, 82% of MDN can be imported
 * 2015-02 - Added MDN importer
@@ -21,5 +17,3 @@ Here are some development milestones:
 * 0.1.0c - 2014-09-16 - Add sample feature view, simplify draft API
 * 0.1.0b - 2014-09-05 - Add filtering, more JSON API tuning.
 * 0.1.0a - 2014-09-02 - First Heroku deployment.  Browser and Version data.
-
-.. _Bugzilla: https://bugzilla.mozilla.org/showdependencytree.cgi?id=996570&hide_resolved=1

--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,11 @@ BrowserCompat API
 
 .. Omit badges from docs
 
-The Browser Compatibility API will support compatibility data on the `Mozilla
-Developer Network`_.  This currently takes the form of browser compatibility
-tables, such as the one on the `CSS display property`_ page.  The API will
-centralize this data, and allow it to be kept consistent across languages and
-presentations.
+The Browser Compatibility API was a project to support compatibility data on
+the `Mozilla Developer Network`_.  This currently takes the form of browser
+compatibility tables, such as the one on the `CSS display property`_ page.  The
+API would centralize this data, and allow it to be kept consistent across
+languages and presentations.
 
 .. _Mozilla Developer Network: https://developer.mozilla.org
 .. _CSS display property: https://developer.mozilla.org/en-US/docs/Web/CSS/display#Browser_compatibility
@@ -36,37 +36,25 @@ documented on the MozillaWiki_.
 
 Status
 ------
+This project has been cancelled.  The have been no code changes since March
+2016. In April 2017, we started the process of removing integration from MDN
+and decommisioning the API server.  See the `issues page`_ for the status
+as of March 2016.
 
-The beta v1 API is being served at https://browsercompat.herokuapp.com/api/v1/.
-Alpha users are using the importer_ to find and fix data issues on MDN. A small
-number of pages on MDN have been converted to use API-backed compatibility
-tables. Beta users can view the new tables, and non-beta users see the
-traditional wiki-backed tables.  As the beta is expanded to more pages and more
-users, the API is changed to handle new use cases. See the `issues page`_ for
-details of planned changes.
+As of 2017, these are the current MDN data projects:
 
-The v1 API uses release candidate 1 (RC1) of the JSON API specification, which
-was released July 2014, but is currently undocumented. See the `v1 API docs`_
-for details of the API implementation.
+* https://github.com/mdn/browser-compat-data
+* https://github.com/mdn/data
 
-.. _`importer`: https://browsercompat.herokuapp.com/importer
-.. _`v1 API docs`: v1/intro.html
 .. _`issues page`: issues.html
-.. _`JSON API v1.0`: https://jsonapi.org/format/1.0/
-.. _`Ember.js`: http://emberjs.com
 
 Development
 -----------
 
 :Code:           https://github.com/mdn/browsercompat
-:Server:         https://browsercompat.herokuapp.com (based on `mdn/browsercompat-data`_)
-:Issues:         https://bugzilla.mozilla.org/buglist.cgi?quicksearch=compat-data (tracking bug)
-
-                 https://bugzilla.mozilla.org/showdependencytree.cgi?id=996570&hide_resolved=1 (blocking issues for v1)
+:Data:           https://github.com/mdn/browsercompat-data
 :Dev Docs:       https://browsercompat.readthedocs.org
 
                  https://github.com/mdn/browsercompat/wiki
 :Mailing list:   https://lists.mozilla.org/listinfo/dev-mdn
 :IRC:            irc://irc.mozilla.org/mdndev
-
-.. _`mdn/browsercompat-data`: https://github.com/mdn/browsercompat-data

--- a/docs/entrypoints.rst
+++ b/docs/entrypoints.rst
@@ -1,15 +1,16 @@
 Entrypoints
 -----------
 
-A developer-centered website is available at
-https://browserscompat.herokuapp.com/.  This site includes
+.. Note:: This project has been cancelled, and this information is historical.
 
-* `/api/v1`_ - The legacy v1 API, conforming to the deprecated `JSON API`_ RC1
+This entrypoints are
+
+* ``/api/v1`` - The legacy v1 API, conforming to the deprecated `JSON API`_ RC1
   specification.
-* `/api/v2`_ - The current v2 API, conforming to the `JSON API v1.0`_
+* ``/api/v2`` - The current v2 API, conforming to the `JSON API v1.0`_
   specification.
-* `/browse`_ - A data browser.
-* `/importer`_ - A tool for scraping and validating data from MDN_.
+* ``/browse`` - A data browser.
+* ``/importer`` - A tool for scraping and validating data from MDN_.
 
 The APIs support two representations:
 
@@ -23,10 +24,6 @@ The API supports user accounts with password and/or Persona_ authentication.
 
 .. _`Django REST Framework browsable API`: http://www.django-rest-framework.org/topics/browsable-api
 .. _Persona: http://www.mozilla.org/en-US/persona/
-.. _`/api/v1`:  https://browsercompat.herokuapp.com/api/v1
 .. _`JSON API`: http://jsonapi.org
-.. _`/api/v2`:  https://browsercompat.herokuapp.com/api/v2
 .. _`JSON API v1.0`: http://jsonapi.org/format/1.0/
-.. _`/browse`: https://browsercompat.herokuapp.com/browse
-.. _`/importer`: https://browsercompat.herokuapp.com/importer
 .. _MDN: https://developer.mozilla.org

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,8 @@
 Installation
 ============
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 Install Django Project
 ----------------------
 For detailed local installation instructions, including OS-specific

--- a/docs/issues.rst
+++ b/docs/issues.rst
@@ -1,5 +1,8 @@
 Issues
 ======
+
+.. Note:: This project has been cancelled, and this information is historical.
+
 The near-term goal is that compatibility data lives in the API rather than on
 the MDN page, and MDN contributors maintain this data in the API instead of
 editing wiki pages. As this plan is executed, limitations are discovered in
@@ -97,6 +100,70 @@ This includes, but is not limited to:
   and standardization supporters, and can be implemented as separate
   applications using the compatibility API.
 
+Bugzilla Archive
+----------------
+BrowserCompat bugs were tracked ib Bugzilla, and closed WONTFIX.  These were
+the open bugs at the time the project was cancelled:
+
+* 996570_: Create a data store for compatibility data
+    * 1078699_: Resources are accessible by slug
+    * 1153329_: Rename project to match browsercompat.org
+    * 1159344_: Reverting a browser should attempt to revert versions order
+    * 1159349_: Allow reverting deletes
+        * 1229785_: No HTTP 410 error page
+    * 1159363_: Add Location header to resource-creating POST responses
+    * 1168455_: Add general email server to browsercompat.herokuapp.com
+    * 1170214_: Limit notes to HTML subset
+    * 1171988_: Restrict API actions by role
+    * 1181140_: [Compat Data][Importer] Improve MDN importer, Round 3
+        * 1134584_: Firefox OS 1.0.1 is not being accepted as a valid version
+            * 1230584_: Improve browsable API for creating and updating resources
+        * 1180573_: Standardized flag is wrong
+        * 1198985_: Adjust handling of <pre> tags with brush class
+    * 1195467_: A version should be unique for a browser
+    * 1197210_: Allow adding new MDN feature pages
+    * 1199483_: Implement Correct Labels on Chrome Browser Table
+        * 1240101_: C&M GUI - display and edit browser and version
+            * 1195467_: A version should be unique for a browser
+    * 1219915_: [Compat] Create macros to import "requires_config" correctly
+    * 1219927_: [Compat] Create macros to import "alternate_name" correctly
+    * 1219945_: [Compat] Create macros to import "protected" correctly
+    * 1224345_: Validation errors on view_feature become ISEs
+        * 1230306_: Switch to database-independant IDs
+    * 1230592_: Logging into API should return to the pre-login page
+    * 1230615_: Add /Add-ons to MDN feature set
+    * 1240757_: Implement v1/v2 API
+        * 1195518_: upload_data tool fails with data_id collision on existing database
+        * 1229170_: [stage] visiting /v1/view_features/fox causes a SystemExit exception
+            * 1230584_: Improve browsable API for creating and updating resources
+        * 1230306_: Switch to database-independant IDs
+        * 1230584_: Improve browsable API for creating and updating resources
+        * 1230597_: Add permission for changing slugs
+        * 1242981_: Use instance cache for v2 API related links
+        * 1251252_: Allow empty Section names
+    * 1240785_: Convert required feature.slug to optional feature.aliases
+        * 1230597_: Add permission for changing slugs
+    * 1242606_: Some pages not re-imported by import_mdn tool
+    * 1242960_: Restrict DELETE on changesets
+    * 1242982_: Use instance cache for v2 relationship links
+    * 1243225_: Fully implement the JSON API v1.0 specification as the v2 API
+        * 1240757_: Implement v1/v2 API
+        * 1242649_: Error responses should use "source" attribute, JSON Pointers
+            * 1240757_: Implement v1/v2 API
+        * 1242664_: Implement POST/DELETE for updating to-many relations
+        * 1242703_: Pagination links are in wrong place for /api/v2/view_features/<id>?child_pages=1
+        * 1242959_: v2 API should not support PUT
+            * 1230584_: Improve browsable API for creating and updating resources
+        * 1243190_: Support "include" parameter
+        * 1243195_: Support "sort" parameter
+        * 1243205_: Support updates through related links in a v2 API
+        * 1243217_: Return 409 Conflict when type and id do not match URL in v2 API
+        * 1252973_: Support "fields" parameter
+    * 1243399_: Automate MDN data scraping
+        * 1247974_: [Importer] Scrape Mozilla/Firefox_OS/API directory
+    * 1244702_: C&M GUI - Provide a basic auth UI for admin
+    * 1246192_: Extract localizable strings from API user interfaces
+
 .. _`bug 1078699`: https://bugzilla.mozilla.org/show_bug.cgi?id=1078699#c2
 .. _`bug 1128525`: https://bugzilla.mozilla.org/show_bug.cgi?id=1128525
 .. _`bug 1230306`: https://bugzilla.mozilla.org/show_bug.cgi?id=1230306
@@ -117,3 +184,62 @@ This includes, but is not limited to:
 .. _`Presto history`: http://www.opera.com/docs/history/presto/
 .. _`Release History of IE`: http://en.wikipedia.org/wiki/Internet_Explorer_1#Release_history_for_desktop_Windows_OS_version
 .. _`Safari version history`: http://en.wikipedia.org/wiki/Safari_version_history#Release_history
+
+.. _996570: https://bugzilla.mozilla.org/show_bug.cgi?id=996570
+.. _1078699: https://bugzilla.mozilla.org/show_bug.cgi?id=1078699
+.. _1153329: https://bugzilla.mozilla.org/show_bug.cgi?id=1153329
+.. _1159344: https://bugzilla.mozilla.org/show_bug.cgi?id=1159344
+.. _1159349: https://bugzilla.mozilla.org/show_bug.cgi?id=1159349
+.. _1229785: https://bugzilla.mozilla.org/show_bug.cgi?id=1229785
+.. _1159363: https://bugzilla.mozilla.org/show_bug.cgi?id=1159363
+.. _1168455: https://bugzilla.mozilla.org/show_bug.cgi?id=1168455
+.. _1170214: https://bugzilla.mozilla.org/show_bug.cgi?id=1170214
+.. _1171988: https://bugzilla.mozilla.org/show_bug.cgi?id=1171988
+.. _1181140: https://bugzilla.mozilla.org/show_bug.cgi?id=1181140
+.. _1134584: https://bugzilla.mozilla.org/show_bug.cgi?id=1134584
+.. _1230584: https://bugzilla.mozilla.org/show_bug.cgi?id=1230584
+.. _1180573: https://bugzilla.mozilla.org/show_bug.cgi?id=1180573
+.. _1198985: https://bugzilla.mozilla.org/show_bug.cgi?id=1198985
+.. _1195467: https://bugzilla.mozilla.org/show_bug.cgi?id=1195467
+.. _1197210: https://bugzilla.mozilla.org/show_bug.cgi?id=1197210
+.. _1199483: https://bugzilla.mozilla.org/show_bug.cgi?id=1199483
+.. _1240101: https://bugzilla.mozilla.org/show_bug.cgi?id=1240101
+.. _1195467: https://bugzilla.mozilla.org/show_bug.cgi?id=1195467
+.. _1219915: https://bugzilla.mozilla.org/show_bug.cgi?id=1219915
+.. _1219927: https://bugzilla.mozilla.org/show_bug.cgi?id=1219927
+.. _1219945: https://bugzilla.mozilla.org/show_bug.cgi?id=1219945
+.. _1224345: https://bugzilla.mozilla.org/show_bug.cgi?id=1224345
+.. _1230306: https://bugzilla.mozilla.org/show_bug.cgi?id=1230306
+.. _1230592: https://bugzilla.mozilla.org/show_bug.cgi?id=1230592
+.. _1230615: https://bugzilla.mozilla.org/show_bug.cgi?id=1230615
+.. _1240757: https://bugzilla.mozilla.org/show_bug.cgi?id=1240757
+.. _1195518: https://bugzilla.mozilla.org/show_bug.cgi?id=1195518
+.. _1229170: https://bugzilla.mozilla.org/show_bug.cgi?id=1229170
+.. _1230584: https://bugzilla.mozilla.org/show_bug.cgi?id=1230584
+.. _1230306: https://bugzilla.mozilla.org/show_bug.cgi?id=1230306
+.. _1230584: https://bugzilla.mozilla.org/show_bug.cgi?id=1230584
+.. _1230597: https://bugzilla.mozilla.org/show_bug.cgi?id=1230597
+.. _1242981: https://bugzilla.mozilla.org/show_bug.cgi?id=1242981
+.. _1251252: https://bugzilla.mozilla.org/show_bug.cgi?id=1251252
+.. _1240785: https://bugzilla.mozilla.org/show_bug.cgi?id=1240785
+.. _1230597: https://bugzilla.mozilla.org/show_bug.cgi?id=1230597
+.. _1242606: https://bugzilla.mozilla.org/show_bug.cgi?id=1242606
+.. _1242960: https://bugzilla.mozilla.org/show_bug.cgi?id=1242960
+.. _1242982: https://bugzilla.mozilla.org/show_bug.cgi?id=1242982
+.. _1243225: https://bugzilla.mozilla.org/show_bug.cgi?id=1243225
+.. _1240757: https://bugzilla.mozilla.org/show_bug.cgi?id=1240757
+.. _1242649: https://bugzilla.mozilla.org/show_bug.cgi?id=1242649
+.. _1240757: https://bugzilla.mozilla.org/show_bug.cgi?id=1240757
+.. _1242664: https://bugzilla.mozilla.org/show_bug.cgi?id=1242664
+.. _1242703: https://bugzilla.mozilla.org/show_bug.cgi?id=1242703
+.. _1242959: https://bugzilla.mozilla.org/show_bug.cgi?id=1242959
+.. _1230584: https://bugzilla.mozilla.org/show_bug.cgi?id=1230584
+.. _1243190: https://bugzilla.mozilla.org/show_bug.cgi?id=1243190
+.. _1243195: https://bugzilla.mozilla.org/show_bug.cgi?id=1243195
+.. _1243205: https://bugzilla.mozilla.org/show_bug.cgi?id=1243205
+.. _1243217: https://bugzilla.mozilla.org/show_bug.cgi?id=1243217
+.. _1252973: https://bugzilla.mozilla.org/show_bug.cgi?id=1252973
+.. _1243399: https://bugzilla.mozilla.org/show_bug.cgi?id=1243399
+.. _1247974: https://bugzilla.mozilla.org/show_bug.cgi?id=1247974
+.. _1244702: https://bugzilla.mozilla.org/show_bug.cgi?id=1244702
+.. _1246192: https://bugzilla.mozilla.org/show_bug.cgi?id=1246192

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -1,6 +1,8 @@
 Services
 ========
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 A **Service** provides server functionality beyond basic manipulation of
 resources.
 

--- a/docs/technologies.rst
+++ b/docs/technologies.rst
@@ -1,6 +1,8 @@
 Technologies
 ------------
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 The technologies used to implement the API include:
 
 * `Django`_, a web framework

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -1,6 +1,8 @@
 Tools
 =====
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 Some potentially useful scripts can be found in the /tools folder:
 
 download_data.py

--- a/docs/v1/intro.rst
+++ b/docs/v1/intro.rst
@@ -1,6 +1,8 @@
 v1 BrowserCompat API
 ====================
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 The v1 API was designed to store and maintain information about web technologies,
 such as HTML and CSS, in the manner used on MDN_.  This takes the form of
 **Specification** tables, which detail the specifications for technologies,

--- a/docs/v2/intro.rst
+++ b/docs/v2/intro.rst
@@ -1,6 +1,8 @@
 v2 BrowserCompat API
 ====================
 
+.. Note:: This project has been cancelled, and this information is historical.
+
 The v2 BrowserCompat API is designed to store and maintain information about
 web technologies, such as HTML and CSS, in the manner used on MDN_.  This takes
 the form of **Specification** tables, which detail the specifications for

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -35,7 +35,6 @@ django-debug-toolbar==1.4 \
     --hash=sha256:852a37b80df9597048591ebc87d0ce85a4edceaef015dc5360ad89cc5960c27b
 
 # Calculate pip 8.x hashes
-hashin==0.3 \
-    --hash=sha256:e86f8b9104df83bda4cf8d000bf21b7fde1ebf3962e67b03fea4c102970d2f95 \
-    --hash=sha256:8015468f50b97cfd4fc8d81fdd99966f1959d8990cee27e24aa79976a2f4ebc1 \
-    --hash=sha256:f8c666b790da4327622ac492fdbcf6caa1b46a0d85fae90eada5213372fafe97
+hashin==0.9.0 \
+    --hash=sha256:814eb85c3cede62e85b11572bfef3f86ff955e89a172e73ef52fe63ca5c95168 \
+    --hash=sha256:e07bb03a35dc6d973a61196cd6d11442649f8faf6085159e7bf4f9d521eec160


### PR DESCRIPTION
The BrowserCompat API project has been abandoned since March 2016.  We're removing the beta integration from MDN, closing bugs as WONTFIX, and updating the docs.